### PR TITLE
Rebuild SwiftSend landing experience in Next.js App Router

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next';
+import { ReactNode } from 'react';
+import { siteMetadata } from '@/lib/seo/metadata';
+import { Header } from '@/components/layout/Header';
+import { Footer } from '@/components/layout/Footer';
+
+import '@/styles/tokens.css';
+import '@/styles/animations.css';
+import '@/styles/globals.css';
+
+export const metadata: Metadata = siteMetadata;
+
+export default function SiteLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <a href="#main-content" className="skip-link">
+          Skip to content
+        </a>
+        <Header />
+        <main id="main-content">{children}</main>
+        <Footer />
+      </body>
+    </html>
+  );
+}

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,0 +1,23 @@
+import { Hero } from './sections/Hero';
+import { About } from './sections/About';
+import { Services } from './sections/Services';
+import { Portfolio } from './sections/Portfolio';
+import { Labs } from './sections/Labs';
+import { Packs } from './sections/Packs';
+import { Process } from './sections/Process';
+import { Contact } from './sections/Contact';
+
+export default function Page() {
+  return (
+    <>
+      <Hero />
+      <About />
+      <Services />
+      <Portfolio />
+      <Labs />
+      <Packs />
+      <Process />
+      <Contact />
+    </>
+  );
+}

--- a/app/(site)/sections/About/About.tsx
+++ b/app/(site)/sections/About/About.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { Container } from '@/components/layout/Container';
+import { useRevealOnce } from '@/hooks/useRevealOnce';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+const achievements = [
+  {
+    title: 'Honors Student',
+    copy: 'Top 1% engineering graduate with research focused on human-centered automation.',
+  },
+  {
+    title: 'STEM Organization Lead',
+    copy: 'Scaled statewide STEM programs and scholarship ops for 2,500+ students.',
+  },
+  {
+    title: 'Adidas Product Ops',
+    copy: 'Automated global launch workflows and brand asset pipelines.',
+  },
+  {
+    title: 'Colmenero Consulting',
+    copy: 'Delivered fintech playbooks from compliance to product velocity.',
+  },
+  {
+    title: 'SwiftSend Founder',
+    copy: 'Bootstrapped a product studio tuned for founder agility and savings.',
+  },
+];
+
+const certificates = [
+  'Google Cloud Certified — Associate Cloud Engineer',
+  'Figma Product Systems Certification',
+  'HubSpot Revenue Operations Professional',
+  'Scrum Alliance Certified ScrumMaster',
+];
+
+export function About() {
+  const profileRef = useRef<HTMLDivElement | null>(null);
+  const avatarRef = useRef<HTMLDivElement | null>(null);
+  const reducedMotion = useReducedMotion();
+  const isDesktop = useMediaQuery('(min-width: 900px) and (pointer: fine)');
+
+  useRevealOnce('.about [data-reveal]');
+
+  useEffect(() => {
+    if (reducedMotion || !isDesktop) {
+      return;
+    }
+
+    const container = profileRef.current;
+    const avatar = avatarRef.current;
+    if (!container || !avatar) {
+      return;
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const rect = container.getBoundingClientRect();
+      const offsetX = ((event.clientX - rect.left) / rect.width - 0.5) * 8;
+      const offsetY = ((event.clientY - rect.top) / rect.height - 0.5) * 6;
+      const clampedX = Math.max(-4, Math.min(4, offsetX));
+      const clampedY = Math.max(-3, Math.min(3, offsetY));
+      avatar.style.transform = `translate3d(${clampedX}px, ${clampedY}px, 0)`;
+    };
+
+    const reset = () => {
+      avatar.style.transform = 'translate3d(0, 0, 0)';
+    };
+
+    container.addEventListener('pointermove', handlePointerMove);
+    container.addEventListener('pointerleave', reset);
+    window.addEventListener('scroll', reset, { passive: true });
+    window.addEventListener('resize', reset);
+
+    return () => {
+      container.removeEventListener('pointermove', handlePointerMove);
+      container.removeEventListener('pointerleave', reset);
+      window.removeEventListener('scroll', reset);
+      window.removeEventListener('resize', reset);
+    };
+  }, [isDesktop, reducedMotion]);
+
+  return (
+    <section id="about" className="about" aria-labelledby="about-heading">
+      <Container className="about__inner">
+        <div className="section-heading" data-reveal>
+          <span className="section-heading__eyebrow">Founder &amp; Crew</span>
+          <h2 className="section-heading__title" id="about-heading">
+            About <span className="grad-word">SwiftSend</span>
+          </h2>
+          <p className="section-heading__lede">
+            SwiftSend grew out of relentless founder energy—shipping software, automation, and growth systems with zero fluff
+            and all accountability. Every engagement is built to hand teams the controls and keep spend lean.
+          </p>
+        </div>
+
+        <div className="about__grid">
+          <div className="about__profile" ref={profileRef} data-reveal>
+            <div className="about__avatar-wrap">
+              <div className="about__avatar-ring" />
+              <div className="about__avatar" ref={avatarRef} aria-hidden="true" />
+            </div>
+            <h3 className="about__name">EJ Colmenero</h3>
+            <p className="about__role">Founder &amp; Principal Engineer</p>
+            <p className="about__bio">
+              I build founder-grade software systems that unlock runways. From architecture to growth motions, my obsession is
+              giving teams the clarity and tools to own their stack end-to-end.
+            </p>
+            <div className="about__quote-card" tabIndex={0} role="listitem">
+              “Every product deserves a fast orbit between idea and impact. SwiftSend keeps that orbit tight.”
+            </div>
+          </div>
+
+          <div className="about__achievements" data-reveal role="list">
+            {achievements.map((item) => (
+              <div key={item.title} className="about__achievement" role="listitem" tabIndex={0}>
+                <h3>{item.title}</h3>
+                <p>{item.copy}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="about__certs" data-reveal>
+          <h3>Certified to Ship</h3>
+          <div className="about__cert-grid">
+            {certificates.map((certificate) => (
+              <div key={certificate} className="about__cert" tabIndex={0}>
+                {certificate}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="about__closing" data-reveal>
+          “We align your stack, your runway, and your roadmap—then ship the product your customers can’t ignore.”
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/app/(site)/sections/About/index.ts
+++ b/app/(site)/sections/About/index.ts
@@ -1,0 +1,1 @@
+export * from './About';

--- a/app/(site)/sections/Contact/Contact.tsx
+++ b/app/(site)/sections/Contact/Contact.tsx
@@ -1,0 +1,56 @@
+import { Container } from '@/components/layout/Container';
+import { ContactForm } from '@/features/forms/ContactForm';
+import { StarfieldCanvas } from '@/features/starfield/StarfieldCanvas';
+import { siteConfig } from '@/config/site';
+
+export function Contact() {
+  return (
+    <section id="contact" className="contact" aria-labelledby="contact-heading">
+      <StarfieldCanvas className="hero__starfield" id="fx-stars-contact" />
+      <Container>
+        <div className="section-heading">
+          <span className="section-heading__eyebrow">Let’s Collaborate</span>
+          <h2 className="section-heading__title" id="contact-heading">
+            Let’s Build Together
+          </h2>
+          <p className="section-heading__lede">
+            Share your mission, timeline, and stack. We’ll respond within one business day with next steps and a savings-first
+            plan to get you shipping.
+          </p>
+        </div>
+
+        <div className="contact__layout">
+          <div className="contact__form-card">
+            <ContactForm />
+          </div>
+          <div className="contact__aside">
+            <div className="contact__panel">
+              <h3>Savings Estimator</h3>
+              <p>
+                Choose a pack to unlock an estimated savings range compared to traditional agencies. We share real numbers once
+                we align on scope.
+              </p>
+            </div>
+            <div className="contact__panel">
+              <h3>Get in Touch</h3>
+              <p>
+                Email us at <a href={`mailto:${siteConfig.contact.email}`}>{siteConfig.contact.email}</a>
+              </p>
+              <p>
+                DM{' '}
+                <a href={siteConfig.contact.instagram} target="_blank" rel="noreferrer">
+                  @swiftsend
+                </a>{' '}
+                on Instagram
+              </p>
+              <p>Response time: under 1 business day</p>
+              <blockquote>
+                “We treat every message as day zero of your launch.”
+              </blockquote>
+            </div>
+          </div>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/app/(site)/sections/Contact/index.ts
+++ b/app/(site)/sections/Contact/index.ts
@@ -1,0 +1,1 @@
+export * from './Contact';

--- a/app/(site)/sections/Hero/Hero.tsx
+++ b/app/(site)/sections/Hero/Hero.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import { Container } from '@/components/layout/Container';
+import { StarfieldCanvas } from '@/features/starfield/StarfieldCanvas';
+
+export function Hero() {
+  return (
+    <section id="home" className="hero" aria-labelledby="hero-heading">
+      <StarfieldCanvas className="hero__starfield" />
+      <Container className="hero__inner">
+        <span className="hero__badge">Founder-first product studio</span>
+        <h1 id="hero-heading" className="hero__title">
+          <span className="grad-word">Your</span> Software.
+          <br />
+          <span className="grad-word">Your</span> Stack.
+          <br />
+          <span className="grad-word">Your</span> Savings.
+        </h1>
+        <p className="hero__lede">
+          SwiftSend powers ambitious teams with full-stack builds, automation, and growth systems that plug directly into the
+          stack you already trust. We meet you where you ship, then push every product milestone forward faster than the
+          agency status quo.
+        </p>
+        <div className="hero__actions">
+          <Link href="#contact" className="hero__action hero__action--primary" aria-label="Start a build with SwiftSend">
+            Start a Build
+            <svg aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path d="M3 8h7.2L7.6 5.4 8.6 4l4.4 4-4.4 4-1-1.4L10.2 8H3z" fill="currentColor" />
+            </svg>
+          </Link>
+          <Link href="#work" className="hero__action hero__action--ghost" aria-label="See SwiftSend work">
+            See Our Work
+            <span className="hero__action-underline" aria-hidden="true" />
+          </Link>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/app/(site)/sections/Hero/index.ts
+++ b/app/(site)/sections/Hero/index.ts
@@ -1,0 +1,1 @@
+export * from './Hero';

--- a/app/(site)/sections/Labs/Labs.tsx
+++ b/app/(site)/sections/Labs/Labs.tsx
@@ -1,0 +1,34 @@
+import { Container } from '@/components/layout/Container';
+import { LabsGlow } from '@/features/labs/LabsGlow';
+
+export function Labs() {
+  return (
+    <section id="labs" className="labs-section" aria-labelledby="labs-heading">
+      <Container>
+        <div className="section-heading">
+          <span className="section-heading__eyebrow">R&D</span>
+          <h2 className="section-heading__title" id="labs-heading">
+            SwiftSend Labs
+          </h2>
+          <p className="section-heading__lede">
+            Product experiments and internal tools that explore the edges of automation, AI copilots, and new go-to-market
+            blueprints before they hit client roadmaps.
+          </p>
+        </div>
+        <div className="labs-section__grid" data-labs-grid>
+          <LabsGlow className="labs-section__glow" />
+          <p>
+            Labs is where we prototype new stacks, validate AI workflows, and spin up playbooks for founders who love a first
+            look. Join the beta to get access as drops go live.
+          </p>
+        </div>
+        <div className="hero__actions" style={{ marginTop: '2.5rem' }}>
+          <a className="hero__action hero__action--ghost" href="#contact" aria-label="Join the Labs beta program">
+            Join the Labs Beta Program
+            <span className="hero__action-underline" aria-hidden="true" />
+          </a>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/app/(site)/sections/Labs/index.ts
+++ b/app/(site)/sections/Labs/index.ts
@@ -1,0 +1,1 @@
+export * from './Labs';

--- a/app/(site)/sections/Packs/Packs.tsx
+++ b/app/(site)/sections/Packs/Packs.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link';
+import { Container } from '@/components/layout/Container';
+import { packs } from '@/data/packs';
+
+const addons = ['AI Bot', 'SwiftPay Mini', 'App Shell', 'DevOps Setup'];
+
+export function Packs() {
+  return (
+    <section id="packs" className="packs" aria-labelledby="packs-heading">
+      <Container>
+        <div className="section-heading">
+          <span className="section-heading__eyebrow">Pricing</span>
+          <h2 className="section-heading__title" id="packs-heading">
+            Choose Your Pack
+          </h2>
+          <p className="section-heading__lede">
+            Four product engagement models tuned to where you are in the journey. Every pack keeps ownership in your hands and
+            trims the bloated agency markup.
+          </p>
+        </div>
+
+        <div className="packs__grid" role="list">
+          {packs.map((pack) => (
+            <article
+              key={pack.key}
+              className="packs__card"
+              data-featured={pack.featured}
+              role="listitem"
+              aria-labelledby={`${pack.key}-title`}
+              aria-describedby={`${pack.key}-desc`}
+              tabIndex={0}
+            >
+              {pack.featured ? <span className="packs__badge">Most Popular</span> : null}
+              <h3 id={`${pack.key}-title`}>{pack.title}</h3>
+              <p className="packs__price">
+                {pack.price} <span className="packs__price-unit">/ {pack.unit}</span>
+              </p>
+              <p id={`${pack.key}-desc`}>{pack.description}</p>
+              <ul className="packs__bullets">
+                {pack.bullets.map((bullet) => (
+                  <li key={bullet}>{bullet}</li>
+                ))}
+              </ul>
+              <Link href="#contact" className="hero__action hero__action--ghost" aria-label={`Start the ${pack.title} pack`}>
+                Start {pack.title}
+                <span className="hero__action-underline" aria-hidden="true" />
+              </Link>
+            </article>
+          ))}
+        </div>
+
+        <div className="packs__addons">
+          <h3>Add-ons</h3>
+          <div className="packs__addons-grid">
+            {addons.map((addon) => (
+              <div key={addon} className="packs__addon" tabIndex={0}>
+                {addon}
+              </div>
+            ))}
+          </div>
+          <div className="hero__actions" style={{ marginTop: '1.5rem' }}>
+            <Link href="#contact" className="hero__action hero__action--primary" aria-label="Discuss add-ons with SwiftSend">
+              Build a Custom Pack
+              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <path d="M3 8h7.2L7.6 5.4 8.6 4l4.4 4-4.4 4-1-1.4L10.2 8H3z" fill="currentColor" />
+              </svg>
+            </Link>
+          </div>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/app/(site)/sections/Packs/index.ts
+++ b/app/(site)/sections/Packs/index.ts
@@ -1,0 +1,1 @@
+export * from './Packs';

--- a/app/(site)/sections/Portfolio/Portfolio.tsx
+++ b/app/(site)/sections/Portfolio/Portfolio.tsx
@@ -1,0 +1,28 @@
+import { Container } from '@/components/layout/Container';
+import { projects } from '@/data/projects';
+import { ProjectCard } from '@/features/portfolio/ProjectCard';
+
+export function Portfolio() {
+  return (
+    <section id="work" className="portfolio" aria-labelledby="portfolio-heading">
+      <Container>
+        <div className="section-heading">
+          <span className="section-heading__eyebrow">Selected Work</span>
+          <h2 className="section-heading__title" id="portfolio-heading">
+            Work That Stands Out
+          </h2>
+          <p className="section-heading__lede">
+            Founder-tested builds that prove speed and savings can live in the same sprint. Every project pushes a mission
+            forward and keeps teams in the driver seat.
+          </p>
+        </div>
+
+        <div className="portfolio__grid">
+          {projects.map((project) => (
+            <ProjectCard key={project.key} project={project} />
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/app/(site)/sections/Portfolio/index.ts
+++ b/app/(site)/sections/Portfolio/index.ts
@@ -1,0 +1,1 @@
+export * from './Portfolio';

--- a/app/(site)/sections/Process/Process.tsx
+++ b/app/(site)/sections/Process/Process.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Container } from '@/components/layout/Container';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+interface Step {
+  key: string;
+  title: string;
+  summary: string;
+  details: string;
+  progress: number;
+}
+
+const steps: Step[] = [
+  {
+    key: 'discover',
+    title: 'Discover',
+    summary: 'Stakeholder syncs, goal setting, and signal hunting.',
+    details:
+      'We map the mission, clarify constraints, and audit your stack so the build plan lands with precision. Expect async intake, stakeholder syncs, and a prioritized playbook.',
+    progress: 0,
+  },
+  {
+    key: 'design',
+    title: 'Design',
+    summary: 'Product flows, UX patterns, and system diagrams.',
+    details:
+      'Interaction models, flows, and brand context snap together quickly. We prototype with your data, define the technical plan, and keep approvals crisp.',
+    progress: 25,
+  },
+  {
+    key: 'build',
+    title: 'Build',
+    summary: 'Engineering sprints with ops-ready delivery.',
+    details:
+      'Engineers, automation, and QA move in lockstep. We keep velocity visible, ship to staging frequently, and ensure the ops handoff is effortless.',
+    progress: 50,
+  },
+  {
+    key: 'launch',
+    title: 'Launch',
+    summary: 'Go-live, analytics, and post-launch acceleration.',
+    details:
+      'Cutover, observability, and growth experiments go live in tandem. We train your crew, leave you with tooling, and line up the next wave of improvements.',
+    progress: 75,
+  },
+];
+
+export function Process() {
+  const [activeStep, setActiveStep] = useState<Step>(steps[0]);
+  const reducedMotion = useReducedMotion();
+
+  const progressValue = useMemo(() => activeStep.progress, [activeStep.progress]);
+
+  return (
+    <section id="process" className="process" aria-labelledby="process-heading">
+      <Container>
+        <div className="section-heading">
+          <span className="section-heading__eyebrow">Method</span>
+          <h2 className="section-heading__title" id="process-heading">
+            How We Work
+          </h2>
+          <p className="section-heading__lede">
+            A transparent, momentum-first process tuned to the way founders build. Every phase keeps you in the loop and locks
+            in measurable progress.
+          </p>
+        </div>
+
+        <div className="process__layout">
+          <aside className="process__progress" aria-label="Project progress">
+            <div className="process__meter" role="presentation">
+              <div
+                className="process__meter-fill"
+                style={{ transform: `scaleX(${progressValue / 100})`, transition: reducedMotion ? 'none' : undefined }}
+              />
+            </div>
+            <div className="process__stops" aria-hidden="true">
+              <span>0%</span>
+              <span>25%</span>
+              <span>50%</span>
+              <span>75%</span>
+              <span>100%</span>
+            </div>
+            <p className="section-heading__lede" style={{ fontSize: '0.95rem' }}>
+              We embed weekly demos, async updates, and transparent backlog access so you always know what landed.
+            </p>
+          </aside>
+
+          <div>
+            <div className="process__tabs" role="tablist" aria-label="Delivery steps">
+              {steps.map((step) => (
+                <button
+                  key={step.key}
+                  type="button"
+                  role="tab"
+                  aria-selected={activeStep.key === step.key}
+                  aria-controls={`process-panel-${step.key}`}
+                  id={`process-tab-${step.key}`}
+                  className="process__tab"
+                  data-active={activeStep.key === step.key}
+                  onClick={() => setActiveStep(step)}
+                >
+                  <span className="process__tab-title">{step.title}</span>
+                  <span className="process__tab-summary">{step.summary}</span>
+                </button>
+              ))}
+            </div>
+
+            <div
+              className="process__panel"
+              id={`process-panel-${activeStep.key}`}
+              role="tabpanel"
+              aria-labelledby={`process-tab-${activeStep.key}`}
+              aria-live="polite"
+            >
+              <h3>{activeStep.title}</h3>
+              <p>{activeStep.details}</p>
+            </div>
+          </div>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/app/(site)/sections/Process/index.ts
+++ b/app/(site)/sections/Process/index.ts
@@ -1,0 +1,1 @@
+export * from './Process';

--- a/app/(site)/sections/Services/Services.tsx
+++ b/app/(site)/sections/Services/Services.tsx
@@ -1,0 +1,155 @@
+import { Container } from '@/components/layout/Container';
+import { services } from '@/data/services';
+
+export function Services() {
+  return (
+    <section id="services" className="services" aria-labelledby="services-heading">
+      <Container>
+        <div className="section-heading">
+          <span className="section-heading__eyebrow">Capabilities</span>
+          <h2 className="section-heading__title" id="services-heading">
+            What We Build
+          </h2>
+          <p className="section-heading__lede">
+            Every engagement is a tightly scoped, velocity-first build. We embed with your crew, ship with your stack, and make
+            sure the momentum sticks after launch.
+          </p>
+        </div>
+
+        <div className="services__grid" role="list">
+          {services.map((service) => (
+            <article key={service.key} className="services__card" role="listitem" tabIndex={0}>
+              <div className="services__icon" aria-hidden="true">
+                {getServiceIcon(service.key)}
+              </div>
+              <h3 className="services__title">{service.title}</h3>
+              <p className="services__copy">{service.copy}</p>
+            </article>
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}
+
+function getServiceIcon(key: string) {
+  switch (key) {
+    case 'fullstack':
+      return (
+        <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="4" y="6" width="28" height="6" rx="2" fill="url(#fs-a)" />
+          <rect x="4" y="16" width="16" height="6" rx="2" fill="url(#fs-b)" />
+          <rect x="4" y="26" width="22" height="6" rx="2" fill="url(#fs-c)" />
+          <defs>
+            <linearGradient id="fs-a" x1="4" y1="6" x2="32" y2="12" gradientUnits="userSpaceOnUse">
+              <stop stopColor="#ff7b39" />
+              <stop offset="1" stopColor="#d63cff" />
+            </linearGradient>
+            <linearGradient id="fs-b" x1="4" y1="16" x2="20" y2="22" gradientUnits="userSpaceOnUse">
+              <stop stopColor="#ffd66b" />
+              <stop offset="1" stopColor="#d63cff" />
+            </linearGradient>
+            <linearGradient id="fs-c" x1="4" y1="26" x2="26" y2="32" gradientUnits="userSpaceOnUse">
+              <stop stopColor="#54f7ce" />
+              <stop offset="1" stopColor="#d63cff" />
+            </linearGradient>
+          </defs>
+        </svg>
+      );
+    case 'data':
+      return (
+        <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M6 12c0-3.3 5.4-6 12-6s12 2.7 12 6-5.4 6-12 6-12-2.7-12-6z" fill="url(#data-a)" />
+          <path d="M6 18c0 3.3 5.4 6 12 6s12-2.7 12-6v6c0 3.3-5.4 6-12 6S6 27.3 6 24v-6z" fill="url(#data-b)" />
+          <defs>
+            <linearGradient id="data-a" x1="6" y1="6" x2="30" y2="18" gradientUnits="userSpaceOnUse">
+              <stop stopColor="#ff7b39" />
+              <stop offset="1" stopColor="#ffd66b" />
+            </linearGradient>
+            <linearGradient id="data-b" x1="6" y1="18" x2="30" y2="30" gradientUnits="userSpaceOnUse">
+              <stop stopColor="#54f7ce" />
+              <stop offset="1" stopColor="#d63cff" />
+            </linearGradient>
+          </defs>
+        </svg>
+      );
+    case 'ai':
+      return (
+        <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="18" cy="18" r="10" stroke="url(#ai-a)" strokeWidth="2" />
+          <circle cx="18" cy="18" r="4" fill="url(#ai-b)" />
+          <path d="M18 6V2" stroke="url(#ai-c)" strokeWidth="2" strokeLinecap="round" />
+          <path d="M30 18h4" stroke="url(#ai-c)" strokeWidth="2" strokeLinecap="round" />
+          <path d="M18 34v-4" stroke="url(#ai-c)" strokeWidth="2" strokeLinecap="round" />
+          <path d="M2 18h4" stroke="url(#ai-c)" strokeWidth="2" strokeLinecap="round" />
+          <defs>
+            <linearGradient id="ai-a" x1="8" y1="8" x2="28" y2="28" gradientUnits="userSpaceOnUse">
+              <stop stopColor="#54f7ce" />
+              <stop offset="1" stopColor="#d63cff" />
+            </linearGradient>
+            <linearGradient id="ai-b" x1="14" y1="14" x2="22" y2="22" gradientUnits="userSpaceOnUse">
+              <stop stopColor="#ff7b39" />
+              <stop offset="1" stopColor="#d63cff" />
+            </linearGradient>
+            <linearGradient id="ai-c" x1="4" y1="2" x2="32" y2="34" gradientUnits="userSpaceOnUse">
+              <stop stopColor="#ffd66b" />
+              <stop offset="1" stopColor="#d63cff" />
+            </linearGradient>
+          </defs>
+        </svg>
+      );
+    case 'swiftpay':
+      return (
+        <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="4" y="8" width="28" height="20" rx="4" fill="url(#pay-a)" />
+          <rect x="8" y="12" width="20" height="3" rx="1.5" fill="rgba(255,255,255,0.7)" />
+          <rect x="8" y="17" width="12" height="3" rx="1.5" fill="rgba(255,255,255,0.5)" />
+          <circle cx="26" cy="23" r="3" fill="rgba(255,255,255,0.9)" />
+          <defs>
+            <linearGradient id="pay-a" x1="4" y1="8" x2="32" y2="28" gradientUnits="userSpaceOnUse">
+              <stop stopColor="#ff7b39" />
+              <stop offset="1" stopColor="#d63cff" />
+            </linearGradient>
+          </defs>
+        </svg>
+      );
+    case 'marketing':
+      return (
+        <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M6 12l14-6v24l-14-6v-12zm19 1a3 3 0 110 6 3 3 0 010-6z"
+            fill="url(#mkt-a)"
+          />
+          <path d="M25 14h5v6h-5a3 3 0 000-6z" fill="url(#mkt-b)" />
+          <defs>
+            <linearGradient id="mkt-a" x1="6" y1="6" x2="20" y2="30" gradientUnits="userSpaceOnUse">
+              <stop stopColor="#ffd66b" />
+              <stop offset="1" stopColor="#d63cff" />
+            </linearGradient>
+            <linearGradient id="mkt-b" x1="25" y1="14" x2="30" y2="20" gradientUnits="userSpaceOnUse">
+              <stop stopColor="#54f7ce" />
+              <stop offset="1" stopColor="#d63cff" />
+            </linearGradient>
+          </defs>
+        </svg>
+      );
+    case 'growth':
+    default:
+      return (
+        <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M8 26l6-8 5 6 8-12 5 5" stroke="url(#growth-a)" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="M6 30h24" stroke="url(#growth-b)" strokeWidth="3" strokeLinecap="round" />
+          <defs>
+            <linearGradient id="growth-a" x1="8" y1="18" x2="32" y2="10" gradientUnits="userSpaceOnUse">
+              <stop stopColor="#ff7b39" />
+              <stop offset="1" stopColor="#54f7ce" />
+            </linearGradient>
+            <linearGradient id="growth-b" x1="6" y1="30" x2="30" y2="30" gradientUnits="userSpaceOnUse">
+              <stop stopColor="#ffd66b" />
+              <stop offset="1" stopColor="#d63cff" />
+            </linearGradient>
+          </defs>
+        </svg>
+      );
+  }
+}

--- a/app/(site)/sections/Services/index.ts
+++ b/app/(site)/sections/Services/index.ts
@@ -1,0 +1,1 @@
+export * from './Services';

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export function GET() {
+  return NextResponse.json({ ok: true });
+}

--- a/components/layout/Container.tsx
+++ b/components/layout/Container.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react';
+import { cn } from '@/lib/utils/cn';
+
+interface ContainerProps {
+  className?: string;
+  children: ReactNode;
+  as?: 'div' | 'section' | 'header' | 'footer';
+}
+
+export function Container({ className, children, as: Component = 'div' }: ContainerProps) {
+  return <Component className={cn('container', className)}>{children}</Component>;
+}

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link';
+import { siteConfig } from '@/config/site';
+import { Container } from './Container';
+
+export function Footer() {
+  return (
+    <footer className="footer" id="footer" role="contentinfo">
+      <Container className="footer__inner">
+        <div className="footer__grid">
+          <div className="footer__brand">
+            <div className="footer__brand-mark" aria-hidden="true">
+              <span className="header__brand-badge">{siteConfig.shortName}</span>
+            </div>
+            <div>
+              <h2 className="footer__brand-name">{siteConfig.name}</h2>
+              <p className="footer__brand-tagline">{siteConfig.tagline}</p>
+            </div>
+            <p className="footer__brand-copy">{siteConfig.description}</p>
+          </div>
+
+          <div className="footer__links">
+            <h3>Quick Links</h3>
+            <nav aria-label="Footer">
+              <ul>
+                {siteConfig.footerLinks.map((item) => (
+                  <li key={item.href}>
+                    <Link href={item.href}>{item.label}</Link>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          </div>
+
+          <div className="footer__connect">
+            <h3>Connect</h3>
+            <a href={`mailto:${siteConfig.contact.email}`}>{siteConfig.contact.email}</a>
+            <a href={siteConfig.contact.instagram} target="_blank" rel="noreferrer">
+              Instagram
+            </a>
+            <div className="footer__social" role="group" aria-label="Social links">
+              <a
+                href={siteConfig.contact.instagram}
+                aria-label="SwiftSend on Instagram"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <svg aria-hidden="true" width="18" height="18" viewBox="0 0 18 18" fill="none">
+                  <path
+                    d="M6 2h6a4 4 0 014 4v6a4 4 0 01-4 4H6a4 4 0 01-4-4V6a4 4 0 014-4zm6 1.5H6a2.5 2.5 0 00-2.5 2.5v6A2.5 2.5 0 006 14.5h6a2.5 2.5 0 002.5-2.5V6A2.5 2.5 0 0012 3.5zm-3 2.3a3.2 3.2 0 110 6.4 3.2 3.2 0 010-6.4zm0 1.5a1.7 1.7 0 100 3.4 1.7 1.7 0 000-3.4zm3.4-.9a.8.8 0 110 1.6.8.8 0 010-1.6z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </a>
+              <a href={`mailto:${siteConfig.contact.email}`} aria-label="Email SwiftSend">
+                <svg aria-hidden="true" width="18" height="18" viewBox="0 0 18 18" fill="none">
+                  <path
+                    d="M2 4h14a1 1 0 011 1v8a1 1 0 01-1 1H2a1 1 0 01-1-1V5a1 1 0 011-1zm13.5 1.5L9 10 2.5 5.5V5l6.5 4.5L15.5 5v.5z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div className="footer__bar">
+          <span>© 2025 SwiftSend</span>
+          <div className="footer__bar-links">
+            <Link href="#privacy">Privacy</Link>
+            <Link href="#terms">Terms</Link>
+          </div>
+        </div>
+      </Container>
+    </footer>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import Link from 'next/link';
+import { siteConfig } from '@/config/site';
+import { Container } from './Container';
+import { useHeaderScroll } from '@/features/header/hooks/useHeaderScroll';
+import { NavMenu } from '@/features/header/components/NavMenu';
+import { cn } from '@/lib/utils/cn';
+
+export function Header() {
+  const hasShadow = useHeaderScroll(10);
+
+  return (
+    <header className={cn('header', hasShadow ? 'has-shadow' : undefined)}>
+      <Container className="header__inner">
+        <Link href="#home" className="header__brand">
+          <span className="header__brand-badge">{siteConfig.shortName}</span>
+          <span className="header__brand-text">{siteConfig.name}</span>
+        </Link>
+
+        <nav className="header__nav" aria-label="Primary">
+          {siteConfig.navigation.map((item) => (
+            <Link key={item.href} href={item.href} className="header__nav-link">
+              <span>{item.label}</span>
+            </Link>
+          ))}
+        </nav>
+
+        <div className="header__icons" role="group" aria-label="Quick actions">
+          <Link href="#search" aria-label="Search SwiftSend" className="header__icon-btn">
+            <svg aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" fill="none">
+              <path
+                d="M9 3a6 6 0 014.8 9.6l2.2 2.2-1 1-2.2-2.2A6 6 0 119 3zm0 1.5a4.5 4.5 0 100 9 4.5 4.5 0 000-9z"
+                fill="currentColor"
+              />
+            </svg>
+          </Link>
+          <a href="tel:+15125552048" aria-label="Call SwiftSend" className="header__icon-btn">
+            <svg aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" fill="none">
+              <path
+                d="M7.9 3.3l1.6 3.4-1.6 1.6a12.4 12.4 0 005.9 5.9l1.6-1.6 3.4 1.6-.01.04c-.36 1.34-1.64 2.27-3.03 2.14-4.3-.42-7.95-4.07-8.37-8.37-.13-1.39.8-2.67 2.14-3.03L7.9 3.3z"
+                fill="currentColor"
+              />
+            </svg>
+          </a>
+          <Link href="#account" aria-label="Account" className="header__icon-btn">
+            <svg aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" fill="none">
+              <path
+                d="M10 3a3 3 0 013 3 3 3 0 11-6 0 3 3 0 013-3zm0 7.5c2.75 0 5.5 1.37 5.5 3.65V16h-11v-1.85c0-2.28 2.75-3.65 5.5-3.65z"
+                fill="currentColor"
+              />
+            </svg>
+          </Link>
+        </div>
+
+        <NavMenu />
+      </Container>
+    </header>
+  );
+}

--- a/config/site.ts
+++ b/config/site.ts
@@ -1,0 +1,34 @@
+import { sectionHref } from '@/lib/utils/routing';
+
+const sections = [
+  { id: 'home', label: 'Home' },
+  { id: 'about', label: 'About' },
+  { id: 'services', label: 'Services' },
+  { id: 'work', label: 'Work' },
+  { id: 'labs', label: 'Labs' },
+  { id: 'packs', label: 'Packs' },
+  { id: 'contact', label: 'Contact' },
+] as const;
+
+export const siteConfig = {
+  name: 'SwiftSend',
+  shortName: 'S',
+  tagline: 'Your Software. Your Stack. Your Savings.',
+  description:
+    'SwiftSend is a cosmic-grade product studio shipping software, automation, and growth experiments for founders who move fast.',
+  navigation: sections.map((section) => ({
+    label: section.label,
+    href: sectionHref(section.id),
+  })),
+  footerLinks: sections.map((section) => ({
+    label: section.label,
+    href: sectionHref(section.id),
+  })),
+  contact: {
+    email: 'build@swiftsend.com',
+    phone: '+1-512-555-2048',
+    instagram: 'https://instagram.com/swiftsend',
+  },
+} as const;
+
+export type SiteConfig = typeof siteConfig;

--- a/data/packs.ts
+++ b/data/packs.ts
@@ -1,0 +1,70 @@
+export interface Pack {
+  key: string;
+  title: string;
+  price: string;
+  unit: string;
+  description: string;
+  bullets: string[];
+  accent: 'orange' | 'magenta' | 'violet' | 'gold';
+  featured?: boolean;
+}
+
+export const packs: Pack[] = [
+  {
+    key: 'starter',
+    title: 'Starter',
+    price: '$2,999',
+    unit: 'one-time',
+    description: 'Perfect for early-stage founders validating a thesis and needing a crisp product sprint.',
+    bullets: [
+      '2-week roadmap & prototype',
+      'Core experience build with your stack',
+      'Analytics & ops instrumentation',
+      'Launch kit + async enablement',
+    ],
+    accent: 'orange',
+  },
+  {
+    key: 'builder',
+    title: 'Builder',
+    price: '$7,999',
+    unit: 'project',
+    description: 'The flagship engagement for teams ready to ship end-to-end product with market polish.',
+    bullets: [
+      '6-week product crew embedded',
+      'Product design, engineering, QA',
+      'Growth experiments + retention loops',
+      'SwiftSend runway planning + ops docs',
+    ],
+    accent: 'magenta',
+    featured: true,
+  },
+  {
+    key: 'engine',
+    title: 'Engine',
+    price: '$15,999',
+    unit: 'project',
+    description: 'Scale-ready architecture, complex integrations, and automation delivered in one motion.',
+    bullets: [
+      'Systems design + architecture runway',
+      'Data pipelines & advanced automations',
+      'Compliance, monitoring, on-call setup',
+      'Founder enablement + ops rituals',
+    ],
+    accent: 'violet',
+  },
+  {
+    key: 'growth',
+    title: 'Growth',
+    price: '$12,999',
+    unit: 'campaign',
+    description: 'Compound your traction with full-funnel creative, paid experiments, and lifecycle orchestration.',
+    bullets: [
+      'Demand gen playbooks & assets',
+      'Paid acquisition sprints',
+      'Lifecycle & retention campaigns',
+      'Experiment tracking + attribution',
+    ],
+    accent: 'gold',
+  },
+];

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -1,0 +1,43 @@
+export interface Project {
+  key: string;
+  title: string;
+  pill: string;
+  problem: string;
+  build: string;
+  outcome: string;
+  image: string;
+  progress: number;
+}
+
+export const projects: Project[] = [
+  {
+    key: 'RealtorDemo',
+    title: 'SwiftSend for Realtors',
+    pill: 'Real Estate Automations',
+    problem: 'Manual lead routing and aging listing data slowed conversions across their three metros.',
+    build: 'Unified MLS ingestion, AI listing copy, and Zapier-ready handoffs inside a custom Next.js command center.',
+    outcome: 'Lead response times dropped 67% while the team shifted to a concierge nurture motion in under 45 days.',
+    image: '/images/portfolio/realtor-demo.jpg',
+    progress: 84,
+  },
+  {
+    key: 'NailTechDemo',
+    title: 'Nail Tech Collective',
+    pill: 'Creator Commerce',
+    problem: 'Stylists juggled DMs, payments, and inventory with no centralized tooling or visibility.',
+    build: 'Launched SwiftPay-backed booking, real-time inventory, and content drops with a low-code marketing suite.',
+    outcome: 'Average order value climbed 42% and drop-day sellouts became the norm after a single quarter.',
+    image: '/images/portfolio/nail-tech-demo.jpg',
+    progress: 76,
+  },
+  {
+    key: 'PhotographerDemo',
+    title: 'Lens & Light Studio',
+    pill: 'Production Workflow',
+    problem: 'Shoot planning, shot lists, and delivery timelines were buried in scattered docs and chats.',
+    build: 'Automated shot planning, client approvals, and delivery with a secure portal plus AI moodboard assists.',
+    outcome: 'Project throughput increased 55% while the crew reclaimed weekends from admin loops.',
+    image: '/images/portfolio/photographer-demo.jpg',
+    progress: 91,
+  },
+];

--- a/data/services.ts
+++ b/data/services.ts
@@ -1,0 +1,52 @@
+export type ServiceKey =
+  | 'fullstack'
+  | 'data'
+  | 'ai'
+  | 'swiftpay'
+  | 'marketing'
+  | 'growth';
+
+export interface Service {
+  key: ServiceKey;
+  title: string;
+  copy: string;
+}
+
+export const services: Service[] = [
+  {
+    key: 'fullstack',
+    title: 'Full-Stack Product Builds',
+    copy:
+      'Concept-to-launch product teams that ship modern web and mobile experiences on the stack you already run.',
+  },
+  {
+    key: 'data',
+    title: 'Data & Automation',
+    copy:
+      'Pipe your data into dashboards, ops automations, and financial insights that keep your crew operating in real-time.',
+  },
+  {
+    key: 'ai',
+    title: 'AI Workflows & Agents',
+    copy:
+      'Deploy copilots, workflow engines, and custom LLM integrations that accelerate delivery and reduce ticket queues.',
+  },
+  {
+    key: 'swiftpay',
+    title: 'SwiftPay Integrations',
+    copy:
+      'Embedded payments, billing reconciliation, and subscription tooling that keep revenue streams humming.',
+  },
+  {
+    key: 'marketing',
+    title: 'Demand Gen Systems',
+    copy:
+      'Launch landing systems, campaign microsites, and growth content that fire up your funnel.',
+  },
+  {
+    key: 'growth',
+    title: 'Lifecycle Experiments',
+    copy:
+      'Retention loops, referral mechanics, and analytics flows engineered to compound every customer touch.',
+  },
+];

--- a/features/forms/ContactForm.tsx
+++ b/features/forms/ContactForm.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { ChangeEvent } from 'react';
+import { useContactForm } from './useContactForm';
+
+const projectOptions = [
+  { value: '', label: 'Select a pack' },
+  { value: 'Starter', label: 'Starter' },
+  { value: 'Builder', label: 'Builder' },
+  { value: 'Engine', label: 'Engine' },
+  { value: 'Growth', label: 'Growth' },
+];
+
+export function ContactForm() {
+  const { values, status, error, summary, onChange, onSubmit, reset } = useContactForm();
+
+  const handleChange = (field: keyof typeof values) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    onChange(field, event.target.value);
+  };
+
+  return (
+    <form className="contact__form" onSubmit={onSubmit} aria-labelledby="contact-heading">
+      <div className="contact__fields">
+        <div className="contact__field">
+          <label htmlFor="contact-name">Name *</label>
+          <input
+            id="contact-name"
+            name="name"
+            type="text"
+            required
+            value={values.name}
+            onChange={handleChange('name')}
+            autoComplete="name"
+          />
+        </div>
+        <div className="contact__field">
+          <label htmlFor="contact-email">Email *</label>
+          <input
+            id="contact-email"
+            name="email"
+            type="email"
+            required
+            value={values.email}
+            onChange={handleChange('email')}
+            autoComplete="email"
+          />
+        </div>
+        <div className="contact__field">
+          <label htmlFor="contact-project">Project Type *</label>
+          <select
+            id="contact-project"
+            name="projectType"
+            required
+            value={values.projectType}
+            onChange={handleChange('projectType')}
+          >
+            {projectOptions.map((option) => (
+              <option key={option.value} value={option.value} disabled={option.value === '' && option.value !== values.projectType}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="contact__field">
+          <label htmlFor="contact-industry">Industry</label>
+          <input
+            id="contact-industry"
+            name="industry"
+            type="text"
+            value={values.industry}
+            onChange={handleChange('industry')}
+            autoComplete="organization"
+            placeholder="Optional"
+          />
+        </div>
+        <div className="contact__field contact__field--full">
+          <label htmlFor="contact-message">Project Notes *</label>
+          <textarea
+            id="contact-message"
+            name="message"
+            required
+            rows={5}
+            value={values.message}
+            onChange={handleChange('message')}
+            placeholder="Share your goals, team, and timeline."
+          />
+        </div>
+      </div>
+
+      <div className="contact__actions">
+        <button type="submit" className="contact__submit" disabled={status === 'submitting'}>
+          <span>Start a Build</span>
+          <svg aria-hidden="true" width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <path
+              d="M3 9h9.6l-3.2-3.2L10.2 4l5.8 5-5.8 5-0.8-1.8L12.6 9H3z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        {status === 'success' ? (
+          <button type="button" className="contact__reset" onClick={reset}>
+            Submit another project
+          </button>
+        ) : null}
+      </div>
+
+      <div className="contact__status" aria-live="polite" role="status">
+        {status === 'submitting' ? 'Sending your project details…' : null}
+        {status === 'success' ? 'We received your project. Expect a reply within one business day.' : null}
+        {status === 'error' && error ? error : null}
+      </div>
+
+      {summary ? (
+        <div className="contact__estimator" role="note">
+          <strong>{summary.plan}</strong>
+          <span>{summary.note}</span>
+        </div>
+      ) : (
+        <p className="contact__estimator contact__estimator--empty">
+          Select a project type to see potential savings.
+        </p>
+      )}
+    </form>
+  );
+}

--- a/features/forms/useContactForm.ts
+++ b/features/forms/useContactForm.ts
@@ -1,0 +1,78 @@
+'use client';
+
+import { FormEvent, useCallback, useMemo, useState } from 'react';
+
+type ContactFields = {
+  name: string;
+  email: string;
+  projectType: string;
+  industry: string;
+  message: string;
+};
+
+type FormStatus = 'idle' | 'submitting' | 'success' | 'error';
+
+const initialValues: ContactFields = {
+  name: '',
+  email: '',
+  projectType: '',
+  industry: '',
+  message: '',
+};
+
+export function useContactForm() {
+  const [values, setValues] = useState<ContactFields>(initialValues);
+  const [status, setStatus] = useState<FormStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const onChange = useCallback((field: keyof ContactFields, value: string) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+  }, []);
+
+  const reset = useCallback(() => {
+    setValues(initialValues);
+    setStatus('idle');
+    setError(null);
+  }, []);
+
+  const onSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      if (!values.name || !values.email || !values.projectType || !values.message) {
+        setStatus('error');
+        setError('Please complete all required fields.');
+        return;
+      }
+
+      setStatus('submitting');
+      setError(null);
+
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      setStatus('success');
+    },
+    [values],
+  );
+
+  const summary = useMemo(() => {
+    if (!values.projectType) {
+      return null;
+    }
+
+    return {
+      plan: values.projectType,
+      note: 'Estimated savings vs. typical agency rates.',
+    };
+  }, [values.projectType]);
+
+  return {
+    values,
+    status,
+    error,
+    summary,
+    onChange,
+    onSubmit,
+    reset,
+  };
+}

--- a/features/header/components/NavMenu.tsx
+++ b/features/header/components/NavMenu.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { siteConfig } from '@/config/site';
+import { cn } from '@/lib/utils/cn';
+
+interface NavMenuProps {
+  onNavigate?: () => void;
+}
+
+export function NavMenu({ onNavigate }: NavMenuProps) {
+  const [open, setOpen] = useState(false);
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const overlay = overlayRef.current;
+    const focusable = overlay?.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+
+    const first = focusable?.[0];
+    const last = focusable?.[focusable.length - 1];
+
+    first?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+        return;
+      }
+
+      if (event.key === 'Tab' && focusable && focusable.length > 0) {
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last?.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first?.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = '';
+      previouslyFocused?.focus();
+    };
+  }, [open]);
+
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.visibilityState === 'hidden') {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, []);
+
+  const closeMenu = () => {
+    setOpen(false);
+    onNavigate?.();
+  };
+
+  return (
+    <div className="header__mobile">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-expanded={open}
+        aria-controls="mobile-nav"
+        className="header__icon-btn"
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span className="visually-hidden">Toggle navigation</span>
+        <svg aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <path
+            d="M3 5h14M3 10h14M3 15h14"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+      </button>
+
+      <div
+        id="mobile-nav"
+        ref={overlayRef}
+        className={cn('header__mobile-overlay', open ? 'is-open' : undefined)}
+        role="dialog"
+        aria-modal="true"
+      >
+        <div className="header__mobile-inner" role="navigation" aria-label="Mobile">
+          <button type="button" className="header__mobile-close" onClick={() => setOpen(false)}>
+            <span className="visually-hidden">Close navigation</span>
+            <svg aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" fill="none">
+              <path
+                d="M4 4l12 12m0-12L4 16"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+
+          <div className="header__mobile-links">
+            {siteConfig.navigation.map((item) => (
+              <Link key={item.href} href={item.href} onClick={closeMenu}>
+                {item.label}
+              </Link>
+            ))}
+          </div>
+
+          <div className="header__mobile-icons">
+            <Link href="#search" aria-label="Search SwiftSend" onClick={closeMenu}>
+              <svg aria-hidden="true" width="22" height="22" viewBox="0 0 22 22" fill="none">
+                <path
+                  d="M10.5 4a6.5 6.5 0 015.18 10.44l2.68 2.68-1.06 1.06-2.68-2.68A6.5 6.5 0 1110.5 4zm0 1.5a5 5 0 100 10 5 5 0 000-10z"
+                  fill="currentColor"
+                />
+              </svg>
+            </Link>
+            <a href="tel:+15125552048" aria-label="Call SwiftSend" onClick={closeMenu}>
+              <svg aria-hidden="true" width="22" height="22" viewBox="0 0 22 22" fill="none">
+                <path
+                  d="M8.9 4.18l1.73 3.62-1.68 1.69a13.8 13.8 0 006.65 6.65l1.69-1.68 3.62 1.73-.01.05c-.39 1.45-1.78 2.46-3.29 2.31-4.7-.46-8.68-4.44-9.14-9.14-.15-1.51.86-2.9 2.31-3.29l.12-.03z"
+                  fill="currentColor"
+                />
+              </svg>
+            </a>
+            <Link href="#account" aria-label="Account" onClick={closeMenu}>
+              <svg aria-hidden="true" width="22" height="22" viewBox="0 0 22 22" fill="none">
+                <path
+                  d="M11 3.5a3.5 3.5 0 013.5 3.5A3.5 3.5 0 1111 3.5zm0 8.25c3.22 0 6.5 1.6 6.5 4.25v1.5h-13v-1.5c0-2.65 3.28-4.25 6.5-4.25z"
+                  fill="currentColor"
+                />
+              </svg>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/features/header/hooks/useHeaderScroll.ts
+++ b/features/header/hooks/useHeaderScroll.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useHeaderScroll(threshold = 12): boolean {
+  const [hasShadow, setHasShadow] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollY = window.scrollY || window.pageYOffset;
+      setHasShadow(scrollY > threshold);
+    };
+
+    handleScroll();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [threshold]);
+
+  return hasShadow;
+}

--- a/features/labs/LabsGlow.tsx
+++ b/features/labs/LabsGlow.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { shouldReduceMotion } from '@/lib/utils/motion';
+
+interface LabsGlowProps {
+  className?: string;
+}
+
+export function LabsGlow({ className }: LabsGlowProps) {
+  const glowRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (shouldReduceMotion()) {
+      return;
+    }
+
+    const glow = glowRef.current;
+    if (!glow) {
+      return;
+    }
+
+    let raf: number | null = null;
+    let start = performance.now();
+
+    const loop = (time: number) => {
+      const elapsed = (time - start) / 1000;
+      const x = Math.sin(elapsed) * 24;
+      const y = Math.cos(elapsed * 0.6) * 18;
+      const scale = 0.95 + Math.sin(elapsed * 0.8) * 0.05;
+      glow.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+      raf = requestAnimationFrame(loop);
+    };
+
+    raf = requestAnimationFrame(loop);
+
+    return () => {
+      if (raf) {
+        cancelAnimationFrame(raf);
+      }
+    };
+  }, []);
+
+  return <div ref={glowRef} className={className} data-labs-orb aria-hidden="true" />;
+}

--- a/features/portfolio/ProjectCard.tsx
+++ b/features/portfolio/ProjectCard.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useState } from 'react';
+import { Project } from '@/data/projects';
+import { useProjectHover } from './useProjectHover';
+import { cn } from '@/lib/utils/cn';
+
+interface ProjectCardProps {
+  project: Project;
+}
+
+export function ProjectCard({ project }: ProjectCardProps) {
+  const [active, setActive] = useState(false);
+  const { imageRef, handlePointerMove, reset } = useProjectHover();
+
+  return (
+    <article
+      className={cn('portfolio-card', active ? 'is-active' : undefined)}
+      aria-labelledby={`${project.key}-title`}
+      tabIndex={0}
+      onPointerEnter={() => setActive(true)}
+      onPointerLeave={() => {
+        setActive(false);
+        reset();
+      }}
+      onFocus={() => setActive(true)}
+      onBlur={() => setActive(false)}
+    >
+      <div
+        className="portfolio-card__media"
+        onPointerMove={handlePointerMove}
+        onPointerLeave={reset}
+        role="presentation"
+      >
+        <div ref={imageRef} className="portfolio-card__image">
+          <Image
+            src={project.image}
+            alt=""
+            fill
+            sizes="(min-width: 960px) 320px, 100vw"
+            priority={false}
+          />
+        </div>
+        <span className="portfolio-card__pill" aria-hidden={!active}>
+          {project.pill}
+        </span>
+        <Link href="#" aria-label={`Open the ${project.title} case study`} className="portfolio-card__cta">
+          <svg aria-hidden="true" width="20" height="20" viewBox="0 0 20 20" fill="none">
+            <path
+              d="M5 5h10v10H5V5zm2 2v6h6V7H7zm6-3H4v13h13V6l-4-4z"
+              fill="currentColor"
+            />
+          </svg>
+        </Link>
+      </div>
+
+      <div className="portfolio-card__content">
+        <h3 id={`${project.key}-title`}>{project.title}</h3>
+        <dl className="portfolio-card__details">
+          <div>
+            <dt>Problem</dt>
+            <dd>{project.problem}</dd>
+          </div>
+          <div>
+            <dt>Build</dt>
+            <dd>{project.build}</dd>
+          </div>
+          <div>
+            <dt>Outcome</dt>
+            <dd>{project.outcome}</dd>
+          </div>
+        </dl>
+        <div className="portfolio-card__progress" aria-hidden="true">
+          <div className="portfolio-card__progress-rail" />
+          <div
+            className="portfolio-card__progress-fill"
+            style={{ transform: `scaleX(${active ? Math.min(1, project.progress / 100) : 0.2})` }}
+          />
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/features/portfolio/useProjectHover.ts
+++ b/features/portfolio/useProjectHover.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { PointerEvent as ReactPointerEvent, useCallback, useRef } from 'react';
+import { shouldReduceMotion } from '@/lib/utils/motion';
+
+export function useProjectHover() {
+  const imageRef = useRef<HTMLDivElement | null>(null);
+  const reduceMotion = shouldReduceMotion();
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (reduceMotion) {
+        return;
+      }
+
+      const element = imageRef.current;
+      if (!element) {
+        return;
+      }
+
+      const bounds = element.getBoundingClientRect();
+      const offsetY = ((event.clientY - bounds.top) / bounds.height - 0.5) * 8;
+      element.style.transform = `translate3d(0, ${offsetY}px, 0)`;
+    },
+    [reduceMotion],
+  );
+
+  const reset = useCallback(() => {
+    const element = imageRef.current;
+    if (element) {
+      element.style.transform = 'translate3d(0, 0, 0)';
+    }
+  }, []);
+
+  return { imageRef, handlePointerMove, reset };
+}

--- a/features/starfield/StarfieldCanvas.tsx
+++ b/features/starfield/StarfieldCanvas.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useRef } from 'react';
+import { useStarfield } from './useStarfield';
+
+interface StarfieldCanvasProps {
+  className?: string;
+  id?: string;
+}
+
+export function StarfieldCanvas({ className, id = 'fx-stars' }: StarfieldCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  useStarfield(canvasRef);
+
+  return <canvas id={id} ref={canvasRef} className={className} aria-hidden="true" />;
+}

--- a/features/starfield/useStarfield.ts
+++ b/features/starfield/useStarfield.ts
@@ -1,0 +1,149 @@
+'use client';
+
+import { RefObject, useEffect, useRef } from 'react';
+import { shouldReduceMotion } from '@/lib/utils/motion';
+
+interface Star {
+  x: number;
+  y: number;
+  z: number;
+  speed: number;
+}
+
+const STAR_COUNT = 160;
+
+export function useStarfield(canvasRef: RefObject<HTMLCanvasElement>) {
+  const animationFrame = useRef<number | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    const context = canvas.getContext('2d');
+    if (!context) {
+      return;
+    }
+
+    let stars: Star[] = [];
+    const reduceMotion = shouldReduceMotion();
+
+    const setup = () => {
+      const { width, height } = getCanvasSize(canvas);
+      stars = Array.from({ length: STAR_COUNT }, () => createStar(width, height));
+    };
+
+    let resizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(() => {
+        resizeCanvas(canvas);
+        setup();
+        if (reduceMotion) {
+          drawStatic(context, stars, canvas);
+        }
+      });
+
+      resizeObserver.observe(canvas);
+    }
+    resizeCanvas(canvas);
+    setup();
+
+    const render = () => {
+      if (!canvas || !context) {
+        return;
+      }
+
+      const { width, height } = canvas;
+      context.clearRect(0, 0, width, height);
+
+      for (const star of stars) {
+        const perspective = 200;
+        const scale = perspective / (perspective + star.z);
+        const x = star.x * scale + width / 2;
+        const y = star.y * scale + height / 2;
+
+        if (reduceMotion) {
+          context.fillStyle = 'rgba(255, 255, 255, 0.6)';
+          context.fillRect(x, y, 2, 2);
+          continue;
+        }
+
+        star.z -= star.speed;
+        if (star.z <= 0) {
+          Object.assign(star, createStar(width, height));
+          star.z = perspective;
+        }
+
+        const radius = Math.max(0.6, 1.8 * (1 - star.z / perspective));
+        context.fillStyle = 'rgba(255, 255, 255, 0.85)';
+        context.beginPath();
+        context.arc(x, y, radius, 0, Math.PI * 2);
+        context.fill();
+      }
+
+      if (!reduceMotion) {
+        animationFrame.current = window.requestAnimationFrame(render);
+      }
+    };
+
+    drawStatic(context, stars, canvas);
+    if (!reduceMotion) {
+      animationFrame.current = window.requestAnimationFrame(render);
+    }
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'hidden' && animationFrame.current) {
+        window.cancelAnimationFrame(animationFrame.current);
+        animationFrame.current = null;
+      } else if (document.visibilityState === 'visible' && !reduceMotion && !animationFrame.current) {
+        animationFrame.current = window.requestAnimationFrame(render);
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      if (animationFrame.current) {
+        window.cancelAnimationFrame(animationFrame.current);
+      }
+      document.removeEventListener('visibilitychange', handleVisibility);
+      resizeObserver?.disconnect();
+    };
+  }, [canvasRef]);
+}
+
+function getCanvasSize(canvas: HTMLCanvasElement) {
+  const { clientWidth, clientHeight } = canvas;
+  return { width: clientWidth, height: clientHeight };
+}
+
+function resizeCanvas(canvas: HTMLCanvasElement) {
+  const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+  const { clientWidth, clientHeight } = canvas;
+  canvas.width = Math.round(clientWidth * dpr);
+  canvas.height = Math.round(clientHeight * dpr);
+  const context = canvas.getContext('2d');
+  if (context) {
+    context.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+}
+
+function createStar(width: number, height: number): Star {
+  return {
+    x: (Math.random() - 0.5) * width,
+    y: (Math.random() - 0.5) * height,
+    z: Math.random() * 200,
+    speed: Math.random() * 0.8 + 0.2,
+  };
+}
+
+function drawStatic(context: CanvasRenderingContext2D, stars: Star[], canvas: HTMLCanvasElement) {
+  context.clearRect(0, 0, canvas.width, canvas.height);
+  for (const star of stars) {
+    const x = star.x + canvas.width / 2;
+    const y = star.y + canvas.height / 2;
+    context.fillStyle = 'rgba(255, 255, 255, 0.45)';
+    context.fillRect(x, y, 2, 2);
+  }
+}

--- a/hooks/useMediaQuery.ts
+++ b/hooks/useMediaQuery.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia === 'undefined') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(query);
+    const update = () => setMatches(mediaQuery.matches);
+
+    update();
+    mediaQuery.addEventListener('change', update);
+
+    return () => {
+      mediaQuery.removeEventListener('change', update);
+    };
+  }, [query]);
+
+  return matches;
+}

--- a/hooks/useReducedMotion.ts
+++ b/hooks/useReducedMotion.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useReducedMotion(): boolean {
+  const [isReduced, setIsReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia === 'undefined') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setIsReduced(mediaQuery.matches);
+
+    update();
+    mediaQuery.addEventListener('change', update);
+
+    return () => {
+      mediaQuery.removeEventListener('change', update);
+    };
+  }, []);
+
+  return isReduced;
+}

--- a/hooks/useRevealOnce.ts
+++ b/hooks/useRevealOnce.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useReducedMotion } from './useReducedMotion';
+
+type Options = {
+  threshold?: number;
+  rootMargin?: string;
+};
+
+export function useRevealOnce(selector: string, options: Options = {}): void {
+  const isReduced = useReducedMotion();
+
+  useEffect(() => {
+    if (isReduced) {
+      const elements = document.querySelectorAll<HTMLElement>(selector);
+      elements.forEach((element) => {
+        element.classList.add('is-in');
+      });
+      return;
+    }
+
+    const elements = Array.from(document.querySelectorAll<HTMLElement>(selector));
+
+    if (!('IntersectionObserver' in window) || elements.length === 0) {
+      elements.forEach((element) => element.classList.add('is-in'));
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-in');
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        threshold: options.threshold ?? 0.18,
+        rootMargin: options.rootMargin ?? '0px',
+      },
+    );
+
+    elements.forEach((element) => observer.observe(element));
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [isReduced, options.rootMargin, options.threshold, selector]);
+}

--- a/lib/seo/metadata.ts
+++ b/lib/seo/metadata.ts
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+
+export const siteMetadata: Metadata = {
+  title: 'SwiftSend — Your Software. Your Stack. Your Savings.',
+  description:
+    'SwiftSend builds software systems that put control and savings back into your hands. From full-stack product design to automation and growth experiments, we ship it with your stack and your goals in mind.',
+  keywords: ['SwiftSend', 'software studio', 'automation', 'Next.js agency', 'product engineering'],
+  themeColor: '#d63cff',
+  openGraph: {
+    title: 'SwiftSend — Your Software. Your Stack. Your Savings.',
+    description:
+      'SwiftSend builds software systems that put control and savings back into your hands. From full-stack product design to automation and growth experiments, we ship it with your stack and your goals in mind.',
+    type: 'website',
+    locale: 'en_US',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'SwiftSend — Your Software. Your Stack. Your Savings.',
+    description:
+      'SwiftSend builds software systems that put control and savings back into your hands. From full-stack product design to automation and growth experiments, we ship it with your stack and your goals in mind.',
+  },
+};

--- a/lib/utils/cn.ts
+++ b/lib/utils/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...values: Array<string | false | null | undefined>): string {
+  return values.filter(Boolean).join(' ');
+}

--- a/lib/utils/motion.ts
+++ b/lib/utils/motion.ts
@@ -1,0 +1,18 @@
+export function shouldReduceMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia === 'undefined') {
+    return false;
+  }
+
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+export const motionDurations = {
+  fast: 0.18,
+  base: 0.28,
+  slow: 0.46,
+} as const;
+
+export const motionEasings = {
+  standard: 'cubic-bezier(0.22, 1, 0.36, 1)',
+  emphasized: 'cubic-bezier(0.33, 1, 0.68, 1)',
+} as const;

--- a/lib/utils/routing.ts
+++ b/lib/utils/routing.ts
@@ -1,0 +1,7 @@
+export function sectionHref(id: string): string {
+  return `#${id}`;
+}
+
+export function isExternalLink(href: string): boolean {
+  return /^https?:\/\//.test(href);
+}

--- a/styles/animations.css
+++ b/styles/animations.css
@@ -1,0 +1,88 @@
+@keyframes starTwinkle {
+  0%, 100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes sweepUnderline {
+  0% {
+    transform: scaleX(0);
+    transform-origin: left;
+    opacity: 0.2;
+  }
+  60% {
+    opacity: 1;
+  }
+  100% {
+    transform: scaleX(1);
+    transform-origin: left;
+    opacity: 1;
+  }
+}
+
+@keyframes pulseGlow {
+  0% {
+    opacity: 0.3;
+    transform: scale(0.96);
+  }
+  50% {
+    opacity: 0.9;
+    transform: scale(1.02);
+  }
+  100% {
+    opacity: 0.3;
+    transform: scale(0.96);
+  }
+}
+
+@keyframes aboutTwinkle {
+  0%, 100% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 0.4;
+  }
+  50% {
+    transform: translate3d(8px, -6px, 0) scale(1.12);
+    opacity: 1;
+  }
+}
+
+@keyframes orbitFloat {
+  0% {
+    transform: translate3d(-10%, -8%, 0) scale(0.85);
+  }
+  50% {
+    transform: translate3d(12%, 16%, 0) scale(1);
+  }
+  100% {
+    transform: translate3d(-10%, -8%, 0) scale(0.85);
+  }
+}
+
+@keyframes labsOrbital {
+  0% {
+    transform: translate3d(-30px, -24px, 0) scale(0.85);
+  }
+  50% {
+    transform: translate3d(30px, 24px, 0) scale(1.1);
+  }
+  100% {
+    transform: translate3d(-30px, -24px, 0) scale(0.85);
+  }
+}
+
+@keyframes gradientSweep {
+  0% {
+    transform: translate3d(-120%, 0, 0);
+    opacity: 0;
+  }
+  30% {
+    opacity: 0.6;
+  }
+  100% {
+    transform: translate3d(180%, 0, 0);
+    opacity: 0;
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,1413 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Clash+Display:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+* {
+  margin: 0;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: radial-gradient(circle at top, rgba(214, 60, 255, 0.18), transparent 45%),
+    radial-gradient(circle at 20% 10%, rgba(255, 120, 40, 0.18), transparent 50%),
+    var(--color-bg);
+  color: var(--color-text);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+img,
+svg,
+video,
+canvas {
+  display: block;
+  max-width: 100%;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  outline: none;
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-accent-sky);
+  outline-offset: 3px;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  padding: 0.6rem 1rem;
+  border-radius: var(--radius-full);
+  background: var(--gradient-primary);
+  color: #050212;
+  z-index: var(--z-dialog);
+  transform: translateY(-140%);
+  transition: transform var(--duration-fast) var(--easing-standard);
+}
+
+.skip-link:focus-visible {
+  transform: translateY(0);
+}
+
+main {
+  display: block;
+}
+
+section {
+  position: relative;
+  isolation: isolate;
+}
+
+[data-reveal] {
+  opacity: 0;
+  transform: translate3d(0, 24px, 0);
+  transition: transform var(--duration-slow) var(--easing-emphasized),
+    opacity var(--duration-slow) var(--easing-emphasized);
+}
+
+[data-reveal].is-in {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
+.container {
+  width: min(1100px, 94vw);
+  margin: 0 auto;
+}
+
+.section-shell {
+  padding: var(--space-3xl) 0;
+}
+
+.section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  max-width: 680px;
+}
+
+.section-heading__eyebrow {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--color-text-soft);
+}
+
+.section-heading__title {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1.1;
+}
+
+.section-heading__title .grad-word {
+  background: var(--gradient-primary);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.section-heading__lede {
+  font-size: 1.05rem;
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}
+
+.hero {
+  position: relative;
+  padding: clamp(7rem, 16vw, 12rem) 0 clamp(5rem, 12vw, 10rem);
+  overflow: hidden;
+}
+
+.hero::before,
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.hero::before {
+  background: radial-gradient(circle at 20% 10%, rgba(255, 136, 76, 0.25), transparent 50%),
+    radial-gradient(circle at 80% 15%, rgba(214, 60, 255, 0.25), transparent 55%);
+}
+
+.hero::after {
+  background-image: url('/images/decor/spark-field.png');
+  background-size: cover;
+  opacity: 0.25;
+  mix-blend-mode: screen;
+}
+
+.hero__inner {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.9rem;
+  border-radius: var(--radius-full);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(12px);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.hero__title {
+  font-family: var(--font-display);
+  font-size: clamp(3rem, 7vw, 5.6rem);
+  line-height: 1.04;
+  letter-spacing: -0.02em;
+}
+
+.hero__title .grad-word {
+  background: var(--gradient-primary);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.hero__lede {
+  max-width: 640px;
+  font-size: 1.15rem;
+  line-height: 1.7;
+  color: var(--color-text-muted);
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.hero__action {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.85rem 1.4rem;
+  border-radius: var(--radius-full);
+  font-weight: 600;
+  transition: transform var(--duration-fast) var(--easing-standard),
+    color var(--duration-fast) var(--easing-standard),
+    background var(--duration-fast) var(--easing-standard);
+  will-change: transform;
+}
+
+.hero__action--primary {
+  background: var(--gradient-primary);
+  color: #050212;
+  box-shadow: var(--shadow-glow);
+}
+
+.hero__action--ghost {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--color-text);
+}
+
+.hero__action::after {
+  content: '';
+  position: absolute;
+  left: 1.2rem;
+  right: 1.2rem;
+  bottom: 0.6rem;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(255, 124, 76, 0), rgba(255, 124, 76, 0.8), rgba(214, 60, 255, 0));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--duration-base) var(--easing-emphasized);
+}
+
+.hero__action:hover,
+.hero__action:focus-visible {
+  transform: translate3d(0, -3px, 0);
+}
+
+.hero__action:hover::after,
+.hero__action:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.hero__action-underline {
+  position: absolute;
+  left: 1.2rem;
+  right: 1.2rem;
+  bottom: 0.5rem;
+  height: 2px;
+  background: var(--gradient-primary);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--duration-base) var(--easing-standard);
+}
+
+.hero__action--ghost:hover .hero__action-underline,
+.hero__action--ghost:focus-visible .hero__action-underline {
+  transform: scaleX(1);
+}
+
+.hero__starfield {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  width: 100%;
+  height: 100%;
+}
+
+.about {
+  position: relative;
+  padding: clamp(6rem, 14vw, 10rem) 0;
+  background: radial-gradient(circle at top, rgba(255, 138, 76, 0.18), transparent 55%),
+    radial-gradient(circle at 80% 20%, rgba(214, 60, 255, 0.18), transparent 65%);
+}
+
+.about::before,
+.about::after {
+  content: '';
+  position: absolute;
+  width: 360px;
+  height: 360px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.35), transparent 65%);
+  opacity: 0.35;
+  filter: blur(8px);
+  animation: aboutTwinkle 22s var(--easing-linear) infinite;
+}
+
+.about::before {
+  top: -120px;
+  left: -160px;
+}
+
+.about::after {
+  bottom: -140px;
+  right: -120px;
+  animation-delay: 9s;
+}
+
+.about__grid {
+  display: grid;
+  gap: var(--space-2xl);
+  position: relative;
+  z-index: 1;
+}
+
+@media (min-width: 900px) {
+  .about__grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.about__profile {
+  position: relative;
+  background: rgba(9, 5, 25, 0.65);
+  border-radius: var(--radius-lg);
+  padding: var(--space-xl);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+}
+
+.about__avatar-wrap {
+  position: relative;
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  margin-bottom: var(--space-md);
+  border: 2px solid rgba(255, 255, 255, 0.22);
+  background: radial-gradient(circle at 30% 30%, rgba(255, 136, 76, 0.9), rgba(214, 60, 255, 0.65));
+  box-shadow: 0 20px 40px rgba(214, 60, 255, 0.4);
+  overflow: hidden;
+}
+
+.about__avatar-ring {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 8px;
+  background: linear-gradient(140deg, rgba(255, 124, 76, 0.8), rgba(214, 60, 255, 0.8));
+}
+
+.about__avatar {
+  position: absolute;
+  inset: 8px;
+  border-radius: 50%;
+  background-image: url('/images/about/profile.jpg');
+  background-size: cover;
+  background-position: center;
+  transition: transform var(--duration-slow) var(--easing-standard);
+  will-change: transform;
+}
+
+.about__name {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  letter-spacing: -0.01em;
+}
+
+.about__role {
+  color: var(--color-text-soft);
+  margin-bottom: var(--space-md);
+}
+
+.about__bio {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-md);
+}
+
+.about__quote-card {
+  margin-top: var(--space-md);
+  padding: var(--space-md);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  position: relative;
+}
+
+.about__quote-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(255, 124, 76, 0.3), rgba(214, 60, 255, 0));
+  opacity: 0;
+  transition: opacity var(--duration-base) var(--easing-standard);
+  pointer-events: none;
+}
+
+.about__quote-card:hover::before,
+.about__quote-card:focus-visible::before {
+  opacity: 1;
+}
+
+.about__achievements {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.about__achievement {
+  position: relative;
+  padding: var(--space-md);
+  border-radius: var(--radius-md);
+  background: rgba(10, 6, 28, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  transition: transform var(--duration-fast) var(--easing-emphasized),
+    border-color var(--duration-fast) var(--easing-standard),
+    box-shadow var(--duration-fast) var(--easing-standard);
+}
+
+.about__achievement::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(255, 124, 76, 0.16), rgba(214, 60, 255, 0));
+  opacity: 0;
+  transition: opacity var(--duration-base) var(--easing-standard);
+}
+
+.about__achievement::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 4px;
+  height: 100%;
+  background: linear-gradient(180deg, rgba(255, 124, 76, 0), rgba(255, 124, 76, 0.65));
+  opacity: 0;
+  transition: opacity var(--duration-base) var(--easing-standard);
+}
+
+.about__achievement:hover,
+.about__achievement:focus-visible {
+  transform: translate3d(0, -6px, 0);
+  border-color: rgba(255, 255, 255, 0.16);
+  box-shadow: var(--shadow-soft);
+}
+
+.about__achievement:hover::after,
+.about__achievement:focus-visible::after,
+.about__achievement:hover::before,
+.about__achievement:focus-visible::before {
+  opacity: 1;
+}
+
+.about__achievement h3 {
+  font-size: 1.1rem;
+  margin-bottom: 0.35rem;
+}
+
+.about__achievement p {
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
+.about__certs {
+  margin-top: var(--space-2xl);
+}
+
+.about__cert-grid {
+  display: grid;
+  gap: var(--space-md);
+}
+
+@media (min-width: 680px) {
+  .about__cert-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.about__cert {
+  padding: var(--space-md);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  transition: transform var(--duration-base) var(--easing-standard),
+    box-shadow var(--duration-base) var(--easing-standard);
+}
+
+.about__cert:hover,
+.about__cert:focus-visible {
+  transform: translate3d(0, -6px, 0);
+  box-shadow: var(--shadow-soft);
+}
+
+.about__closing {
+  margin-top: var(--space-2xl);
+  padding: var(--space-xl);
+  border-radius: var(--radius-lg);
+  background: rgba(10, 6, 28, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 1.1rem;
+  line-height: 1.7;
+  color: var(--color-text-muted);
+}
+
+.services {
+  padding: clamp(6rem, 14vw, 10rem) 0;
+}
+
+.services__grid {
+  display: grid;
+  gap: var(--space-md);
+  margin-top: var(--space-xl);
+}
+
+@media (min-width: 720px) {
+  .services__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.services__card {
+  position: relative;
+  padding: var(--space-xl);
+  border-radius: var(--radius-lg);
+  background: rgba(8, 5, 22, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  transition: transform var(--duration-fast) var(--easing-emphasized),
+    box-shadow var(--duration-fast) var(--easing-standard),
+    border-color var(--duration-fast) var(--easing-standard);
+}
+
+.services__card::after {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(255, 124, 76, 0.14), rgba(214, 60, 255, 0));
+  opacity: 0;
+  transition: opacity var(--duration-base) var(--easing-standard);
+}
+
+.services__card:hover,
+.services__card:focus-visible {
+  transform: translate3d(0, -8px, 0);
+  border-color: rgba(255, 255, 255, 0.16);
+  box-shadow: var(--shadow-soft);
+}
+
+.services__card:hover::after,
+.services__card:focus-visible::after {
+  opacity: 1;
+}
+
+.services__icon {
+  width: 42px;
+  height: 42px;
+  margin-bottom: var(--space-md);
+}
+
+.services__title {
+  font-size: 1.2rem;
+  margin-bottom: 0.5rem;
+}
+
+.services__copy {
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}
+
+.portfolio {
+  padding: clamp(6rem, 14vw, 10rem) 0;
+}
+
+.portfolio__grid {
+  display: grid;
+  gap: var(--space-xl);
+  margin-top: var(--space-xl);
+}
+
+@media (min-width: 860px) {
+  .portfolio__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.labs-section {
+  padding: clamp(6rem, 14vw, 10rem) 0;
+  background: radial-gradient(circle at 15% 10%, rgba(255, 124, 76, 0.16), transparent 60%),
+    radial-gradient(circle at 85% 15%, rgba(214, 60, 255, 0.18), transparent 60%);
+}
+
+.labs-section__grid {
+  margin-top: var(--space-xl);
+  padding: var(--space-xl);
+  border-radius: var(--radius-lg);
+  background: rgba(10, 6, 28, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  min-height: 220px;
+  position: relative;
+  overflow: hidden;
+}
+
+.labs-section__glow {
+  position: absolute;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(214, 60, 255, 0.45), rgba(214, 60, 255, 0));
+  filter: blur(12px);
+  top: 20%;
+  left: 10%;
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.packs {
+  padding: clamp(6rem, 14vw, 10rem) 0;
+}
+
+.packs__grid {
+  display: grid;
+  gap: var(--space-lg);
+  margin-top: var(--space-xl);
+}
+
+@media (min-width: 900px) {
+  .packs__grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.packs__card {
+  position: relative;
+  padding: var(--space-xl);
+  border-radius: var(--radius-lg);
+  background: rgba(10, 6, 28, 0.68);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  transition: transform var(--duration-fast) var(--easing-emphasized),
+    box-shadow var(--duration-fast) var(--easing-standard),
+    border-color var(--duration-fast) var(--easing-standard);
+}
+
+.packs__card[data-featured='true'] {
+  border: 1px solid rgba(255, 124, 76, 0.45);
+  box-shadow: var(--shadow-glow);
+}
+
+.packs__card:hover,
+.packs__card:focus-visible {
+  transform: translate3d(0, -10px, 0);
+  box-shadow: var(--shadow-soft);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.packs__badge {
+  align-self: flex-start;
+  padding: 0.4rem 0.9rem;
+  border-radius: var(--radius-full);
+  background: rgba(255, 255, 255, 0.1);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+}
+
+.packs__price {
+  font-family: var(--font-display);
+  font-size: 2.4rem;
+  line-height: 1;
+}
+
+.packs__price-unit {
+  font-size: 0.9rem;
+  color: var(--color-text-soft);
+}
+
+.packs__bullets {
+  display: grid;
+  gap: 0.55rem;
+  color: var(--color-text-muted);
+  padding-left: 1.1rem;
+}
+
+.packs__bullets li {
+  list-style: disc;
+}
+
+.packs__addons {
+  margin-top: var(--space-2xl);
+  display: grid;
+  gap: var(--space-md);
+}
+
+.packs__addons-grid {
+  display: grid;
+  gap: var(--space-md);
+}
+
+@media (min-width: 720px) {
+  .packs__addons-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: var(--space-md);
+  }
+}
+
+.packs__addon {
+  padding: var(--space-md);
+  border-radius: var(--radius-md);
+  background: rgba(12, 8, 32, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  transition: transform var(--duration-base) var(--easing-standard);
+}
+
+.packs__addon:hover,
+.packs__addon:focus-visible {
+  transform: translate3d(0, -6px, 0);
+}
+
+.process {
+  padding: clamp(6rem, 14vw, 10rem) 0;
+}
+
+.process__layout {
+  display: grid;
+  gap: var(--space-2xl);
+}
+
+@media (min-width: 960px) {
+  .process__layout {
+    grid-template-columns: 360px 1fr;
+    align-items: start;
+  }
+}
+
+.process__progress {
+  padding: var(--space-xl);
+  border-radius: var(--radius-lg);
+  background: rgba(8, 5, 22, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.process__meter {
+  position: relative;
+  width: 100%;
+  height: 16px;
+  border-radius: var(--radius-full);
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.process__meter-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left;
+  background: var(--gradient-primary);
+  transition: transform var(--duration-base) var(--easing-emphasized);
+}
+
+.process__stops {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: var(--color-text-soft);
+}
+
+.process__tabs {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.process__tab {
+  padding: var(--space-md);
+  border-radius: var(--radius-md);
+  background: rgba(8, 5, 22, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: 0.35rem;
+  transition: transform var(--duration-fast) var(--easing-standard),
+    border-color var(--duration-fast) var(--easing-standard);
+}
+
+.process__tab-title {
+  font-weight: 600;
+}
+
+.process__tab-summary {
+  color: var(--color-text-soft);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.process__tab[data-active='true'] {
+  border-color: rgba(255, 124, 76, 0.45);
+  transform: translate3d(0, -4px, 0);
+}
+
+.process__panel {
+  margin-top: var(--space-xl);
+  padding: var(--space-xl);
+  border-radius: var(--radius-lg);
+  background: rgba(12, 8, 32, 0.68);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: var(--shadow-soft);
+}
+
+.contact {
+  padding: clamp(6rem, 14vw, 10rem) 0;
+  background: radial-gradient(circle at 25% 15%, rgba(255, 124, 76, 0.14), transparent 60%),
+    radial-gradient(circle at 85% 25%, rgba(214, 60, 255, 0.18), transparent 65%);
+}
+
+.contact__layout {
+  display: grid;
+  gap: var(--space-2xl);
+}
+
+@media (min-width: 920px) {
+  .contact__layout {
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  }
+}
+
+.contact__form-card {
+  position: relative;
+  padding: var(--space-xl);
+  border-radius: var(--radius-lg);
+  background: rgba(10, 6, 28, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: var(--shadow-soft);
+}
+
+.contact__aside {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.contact__panel {
+  padding: var(--space-lg);
+  border-radius: var(--radius-lg);
+  background: rgba(10, 6, 28, 0.68);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.contact__panel h3 {
+  font-size: 1.2rem;
+  margin-bottom: 0.4rem;
+}
+
+.contact__panel blockquote {
+  margin-top: 0.75rem;
+  font-style: italic;
+  color: var(--color-text-soft);
+}
+
+.footer {
+  padding: clamp(4rem, 10vw, 6rem) 0 2rem;
+  background: radial-gradient(circle at top, rgba(214, 60, 255, 0.18), transparent 60%),
+    rgba(5, 2, 18, 0.95);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.footer__grid {
+  display: grid;
+  gap: var(--space-xl);
+  margin-bottom: var(--space-2xl);
+}
+
+@media (min-width: 900px) {
+  .footer__grid {
+    grid-template-columns: 1.1fr repeat(2, minmax(0, 1fr));
+  }
+}
+
+.footer__brand {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.footer__brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.footer__brand-name {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+}
+
+.footer__brand-tagline {
+  color: var(--color-text-soft);
+}
+
+.footer__brand-copy {
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}
+
+.footer__links,
+.footer__connect {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.footer__links ul {
+  list-style: none;
+  display: grid;
+  gap: 0.45rem;
+  padding: 0;
+}
+
+.footer__social {
+  display: inline-flex;
+  gap: 0.8rem;
+  margin-top: 0.5rem;
+}
+
+.footer__bar {
+  padding-top: var(--space-lg);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  justify-content: space-between;
+  align-items: center;
+  color: var(--color-text-soft);
+}
+
+.footer__bar-links {
+  display: inline-flex;
+  gap: var(--space-md);
+}
+
+.footer__bar-links a {
+  position: relative;
+  padding-bottom: 0.2rem;
+}
+
+.footer__bar-links a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  background: var(--gradient-primary);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--duration-base) var(--easing-standard);
+}
+
+.footer__bar-links a:hover::after,
+.footer__bar-links a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.header {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-overlay);
+  background: linear-gradient(90deg, rgba(255, 124, 76, 0.18), rgba(214, 60, 255, 0.14))
+      rgba(5, 2, 18, 0.4);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  transition: box-shadow var(--duration-fast) var(--easing-standard),
+    background var(--duration-fast) var(--easing-standard);
+}
+
+.header.has-shadow {
+  box-shadow: 0 10px 30px rgba(10, 6, 28, 0.35);
+  background: linear-gradient(90deg, rgba(255, 124, 76, 0.2), rgba(214, 60, 255, 0.18))
+      rgba(5, 2, 18, 0.72);
+}
+
+.header__inner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-lg);
+  min-height: 76px;
+}
+
+.header__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  font-size: 1.05rem;
+}
+
+.header__brand-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 12px;
+  background: var(--gradient-primary);
+  color: #050212;
+  font-weight: 700;
+}
+
+.header__nav {
+  display: none;
+  margin-left: auto;
+  gap: var(--space-sm);
+}
+
+.header__nav-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.1rem;
+  border-radius: var(--radius-full);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid transparent;
+  transition: transform var(--duration-fast) var(--easing-standard),
+    border-color var(--duration-fast) var(--easing-standard);
+}
+
+.header__nav-link span::after {
+  content: '';
+  position: absolute;
+  inset: auto 12px 8px;
+  height: 2px;
+  background: var(--gradient-primary);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--duration-base) var(--easing-standard);
+}
+
+.header__nav-link:hover,
+.header__nav-link:focus-visible {
+  transform: translate3d(0, -3px, 0);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.header__nav-link:hover span::after,
+.header__nav-link:focus-visible span::after {
+  transform: scaleX(1);
+}
+
+.header__icons {
+  display: none;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.header__icon-btn {
+  position: relative;
+  width: 38px;
+  height: 38px;
+  border-radius: var(--radius-full);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  transition: transform var(--duration-fast) var(--easing-standard),
+    border-color var(--duration-fast) var(--easing-standard);
+}
+
+.header__icon-btn:hover,
+.header__icon-btn:focus-visible {
+  transform: translate3d(0, -3px, 0);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.header__mobile {
+  margin-left: auto;
+}
+
+.header__mobile-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 2, 18, 0.94);
+  backdrop-filter: blur(12px);
+  transform: translateY(-100%);
+  opacity: 0;
+  transition: transform var(--duration-base) var(--easing-emphasized),
+    opacity var(--duration-base) var(--easing-emphasized);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-dialog);
+  pointer-events: none;
+}
+
+.header__mobile-overlay.is-open {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.header__mobile-inner {
+  position: relative;
+  width: min(520px, 90vw);
+  display: grid;
+  gap: var(--space-xl);
+  text-align: center;
+}
+
+.header__mobile-close {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 42px;
+  height: 42px;
+  border-radius: var(--radius-full);
+  background: rgba(255, 255, 255, 0.08);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.header__mobile-links {
+  display: grid;
+  gap: var(--space-md);
+  font-size: 1.4rem;
+}
+
+.header__mobile-links a {
+  padding: 0.8rem 1rem;
+  border-radius: var(--radius-full);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.header__mobile-icons {
+  display: inline-flex;
+  justify-content: center;
+  gap: var(--space-md);
+}
+
+@media (min-width: 960px) {
+  .header__nav {
+    display: inline-flex;
+  }
+
+  .header__icons {
+    display: inline-flex;
+  }
+
+  .header__mobile {
+    display: none;
+  }
+}
+
+.portfolio-card {
+  position: relative;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: rgba(12, 8, 32, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: var(--space-md);
+  padding-bottom: var(--space-lg);
+  transition: transform var(--duration-fast) var(--easing-emphasized),
+    box-shadow var(--duration-fast) var(--easing-standard),
+    border-color var(--duration-fast) var(--easing-standard);
+}
+
+.portfolio-card.is-active {
+  transform: translate3d(0, -8px, 0);
+  border-color: rgba(255, 255, 255, 0.16);
+  box-shadow: var(--shadow-soft);
+}
+
+.portfolio-card__media {
+  position: relative;
+  height: 220px;
+  overflow: hidden;
+}
+
+.portfolio-card__image {
+  position: absolute;
+  inset: 0;
+  transition: transform var(--duration-slow) var(--easing-standard);
+}
+
+.portfolio-card__image img {
+  object-fit: cover;
+}
+
+.portfolio-card__pill {
+  position: absolute;
+  bottom: 16px;
+  left: 16px;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-full);
+  background: rgba(5, 2, 18, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  opacity: 0;
+  transition: opacity var(--duration-fast) var(--easing-standard);
+}
+
+.portfolio-card.is-active .portfolio-card__pill {
+  opacity: 1;
+}
+
+.portfolio-card__cta {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 42px;
+  height: 42px;
+  border-radius: var(--radius-full);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.portfolio-card__content {
+  display: grid;
+  gap: var(--space-md);
+  padding: 0 var(--space-lg);
+}
+
+.portfolio-card__details {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.portfolio-card__details dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--color-text-soft);
+}
+
+.portfolio-card__details dd {
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}
+
+.portfolio-card__progress {
+  position: relative;
+  height: 8px;
+  border-radius: var(--radius-full);
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.portfolio-card__progress-rail {
+  display: none;
+}
+
+.portfolio-card__progress-fill {
+  position: absolute;
+  inset: 0;
+  background: var(--gradient-primary);
+  transform-origin: left;
+  transition: transform var(--duration-base) var(--easing-emphasized);
+}
+
+.contact__form {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.contact__fields {
+  display: grid;
+  gap: var(--space-md);
+}
+
+@media (min-width: 680px) {
+  .contact__fields {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.contact__field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.contact__field--full {
+  grid-column: 1 / -1;
+}
+
+.contact__field label {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-soft);
+}
+
+.contact__field input,
+.contact__field select,
+.contact__field textarea {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.75rem 1rem;
+  color: var(--color-text);
+  transition: border-color var(--duration-fast) var(--easing-standard),
+    box-shadow var(--duration-fast) var(--easing-standard);
+}
+
+.contact__field input:focus-visible,
+.contact__field select:focus-visible,
+.contact__field textarea:focus-visible {
+  border-color: rgba(255, 255, 255, 0.4);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.2);
+}
+
+.contact__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.contact__submit {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.8rem 1.4rem;
+  border-radius: var(--radius-full);
+  background: var(--gradient-primary);
+  color: #050212;
+  font-weight: 600;
+  transition: transform var(--duration-fast) var(--easing-standard);
+}
+
+.contact__submit:disabled {
+  opacity: 0.7;
+}
+
+.contact__submit:not(:disabled):hover,
+.contact__submit:not(:disabled):focus-visible {
+  transform: translate3d(0, -3px, 0);
+}
+
+.contact__reset {
+  background: none;
+  color: var(--color-text-muted);
+  text-decoration: underline;
+}
+
+.contact__status {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+}
+
+.contact__estimator {
+  display: grid;
+  gap: 0.35rem;
+  padding: var(--space-md);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.contact__estimator strong {
+  font-size: 1.1rem;
+}
+
+.contact__estimator--empty {
+  color: var(--color-text-soft);
+}
+
+.contact__form-card .hero__starfield {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .hero__action,
+  .services__card,
+  .portfolio__grid > *,
+  .about__achievement,
+  .about__cert,
+  .packs__card,
+  .packs__addon,
+  .process__tab {
+    transition: none !important;
+  }
+}

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,0 +1,72 @@
+:root {
+  --color-bg: #050212;
+  --color-surface: rgba(15, 10, 30, 0.85);
+  --color-surface-strong: rgba(18, 12, 38, 0.95);
+  --color-surface-soft: rgba(22, 16, 46, 0.65);
+  --color-border: rgba(255, 255, 255, 0.08);
+  --color-border-strong: rgba(255, 255, 255, 0.16);
+  --color-text: #f6f6ff;
+  --color-text-muted: rgba(230, 225, 255, 0.74);
+  --color-text-soft: rgba(220, 215, 245, 0.58);
+  --color-heading: #ffffff;
+  --color-primary-start: #ff7b39;
+  --color-primary-end: #d63cff;
+  --color-primary: #ff6f61;
+  --color-accent-gold: #ffd66b;
+  --color-accent-emerald: #54f7ce;
+  --color-accent-lilac: #b68bff;
+  --color-accent-sky: #48c7ff;
+  --gradient-primary: linear-gradient(135deg, var(--color-primary-start), var(--color-primary-end));
+  --gradient-magenta: linear-gradient(135deg, #f7797d, #fbd786, #c6ffdd);
+  --gradient-surface: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0));
+  --gradient-rail: linear-gradient(90deg, rgba(255, 124, 76, 0.45), rgba(207, 55, 255, 0.28));
+
+  --font-sans: 'Inter', 'Inter var', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-display: 'Clash Display', 'Inter', 'Inter var', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+  --space-xs: 0.375rem;
+  --space-sm: 0.75rem;
+  --space-md: 1.25rem;
+  --space-lg: 2rem;
+  --space-xl: 3rem;
+  --space-2xl: 4rem;
+  --space-3xl: 6rem;
+
+  --radius-sm: 0.5rem;
+  --radius-md: 1rem;
+  --radius-lg: 1.5rem;
+  --radius-xl: 2.5rem;
+  --radius-full: 999px;
+
+  --shadow-soft: 0 20px 40px rgba(18, 13, 43, 0.35);
+  --shadow-lifted: 0 30px 60px rgba(18, 13, 43, 0.45);
+  --shadow-glow: 0 0 60px rgba(214, 60, 255, 0.35);
+  --shadow-ring: 0 0 0 1px rgba(255, 255, 255, 0.18);
+
+  --duration-fast: 180ms;
+  --duration-base: 280ms;
+  --duration-slow: 460ms;
+
+  --easing-standard: cubic-bezier(0.22, 1, 0.36, 1);
+  --easing-emphasized: cubic-bezier(0.33, 1, 0.68, 1);
+  --easing-linear: cubic-bezier(0, 0, 1, 1);
+
+  --z-backdrop: 0;
+  --z-base: 1;
+  --z-overlay: 10;
+  --z-dialog: 20;
+  --z-tooltip: 30;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --color-bg: #f7f6ff;
+    --color-surface: rgba(255, 255, 255, 0.92);
+    --color-surface-strong: rgba(255, 255, 255, 0.98);
+    --color-surface-soft: rgba(255, 255, 255, 0.78);
+    --color-text: #120a2a;
+    --color-text-muted: rgba(18, 10, 42, 0.74);
+    --color-heading: #0e0626;
+  }
+}


### PR DESCRIPTION
## Summary
- implement the complete SwiftSend landing page using the App Router with hero, about, services, portfolio, labs, packs, process, and contact sections wired to typed data sources
- add interactive flourishes including the animated starfield, reduced-motion aware reveals, mobile navigation overlay, and a contact form with estimator feedback
- define reusable design tokens, global animations, and utility hooks/utilities to support the cosmic gradient visual language and accessibility requirements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e36fd9e50c832f930647d644a1cb88