### PR TITLE
Implement SwiftSend header and tooling baseline

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,0 +1,20 @@
+import "@/styles/globals.css";
+import Header from "@/components/layout/Header";
+import type { ReactNode } from "react";
+
+export const metadata = {
+  title: "SwiftSend — Your Software. Your Stack. Your Savings.",
+  themeColor: "#d63cff"
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        {/* Header is rendered via the component below */}
+        <Header />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { MouseEvent } from "react";
+
+const NAV_LINKS = [
+  { href: "#home", label: "Home" },
+  { href: "#services", label: "Services" },
+  { href: "#portfolio", label: "Work" },
+  { href: "#labs", label: "Labs" },
+  { href: "#packs", label: "Packs" },
+  { href: "#about", label: "About" },
+  { href: "#contact", label: "Contact" }
+];
+
+export default function Header() {
+  const [open, setOpen] = useState(false);
+  const headerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const el = headerRef.current;
+    if (!el) return;
+
+    const HEADER_FADE_MIN = 120;
+    const HEADER_FADE_MAX = 220;
+    const HEADER_FADE_THRESHOLD = 220;
+    const SAFE = Math.min(Math.max(HEADER_FADE_THRESHOLD, HEADER_FADE_MIN), HEADER_FADE_MAX);
+
+    const onScroll = () => {
+      const y = window.scrollY || document.documentElement.scrollTop;
+      if (y <= HEADER_FADE_MIN) {
+        el.classList.remove("header-fade");
+        return;
+      }
+      el.classList.toggle("header-fade", y > SAFE);
+    };
+
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+    };
+  }, []);
+
+  useEffect(() => {
+    const setActive = () => {
+      const hash = window.location.hash || "#home";
+      document.querySelectorAll<HTMLAnchorElement>(".nav-pill").forEach((el) => el.classList.remove("is-active"));
+      const target = document.querySelector<HTMLAnchorElement>(`.nav-pill[href="${hash}"]`);
+      if (target) target.classList.add("is-active");
+    };
+
+    setActive();
+    window.addEventListener("hashchange", setActive);
+    return () => window.removeEventListener("hashchange", setActive);
+  }, []);
+
+  const handleOverlayClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <header ref={headerRef} className="ss-header" data-header>
+      <div className="container header-row">
+        <a href="#home" className="brand" aria-label="SwiftSend">
+          <span className="brand-badge">S</span>
+          <span className="brand-text">SwiftSend</span>
+        </a>
+
+        <nav className="nav-desktop" aria-label="Primary">
+          {NAV_LINKS.map((link) => (
+            <a key={link.href} href={link.href} className="nav-pill">
+              <span>{link.label}</span>
+            </a>
+          ))}
+        </nav>
+
+        <div className="header-icons">
+          <button className="icon-btn" aria-label="Search">
+            {SearchIcon}
+          </button>
+          <a className="icon-btn" aria-label="Call" href="tel:+1">
+            {PhoneIcon}
+          </a>
+          <button className="icon-btn" aria-label="Account">
+            {UserIcon}
+          </button>
+          <button
+            className="hamburger"
+            aria-label="Open menu"
+            aria-expanded={open ? "true" : "false"}
+            aria-controls="mobileMenu"
+            onClick={() => setOpen(true)}
+          >
+            <span />
+            <span />
+            <span />
+          </button>
+        </div>
+      </div>
+
+      <div
+        id="mobileMenu"
+        className="mobile-overlay"
+        hidden={!open}
+        onClick={handleOverlayClick}
+      >
+        <div className="overlay-panel">
+          <div className="overlay-top">
+            <span className="brand-badge" aria-hidden="true">
+              S
+            </span>
+            <button className="overlay-close" aria-label="Close menu" onClick={() => setOpen(false)}>
+              ✕
+            </button>
+          </div>
+
+          <nav className="overlay-nav" aria-label="Mobile">
+            {NAV_LINKS.map((link) => (
+              <a key={link.href} href={link.href} onClick={() => setOpen(false)}>
+                {link.label}
+              </a>
+            ))}
+          </nav>
+
+          <div className="overlay-icons">
+            <button className="icon-btn" aria-label="Search (mobile)">
+              {SearchIcon}
+            </button>
+            <a className="icon-btn" aria-label="Call (mobile)" href="tel:+1">
+              {PhoneIcon}
+            </a>
+            <button className="icon-btn" aria-label="Account (mobile)">
+              {UserIcon}
+            </button>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+const SearchIcon = (
+  <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+    <circle cx="11" cy="11" r="7" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);
+
+const PhoneIcon = (
+  <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+    <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.79 19.79 0 0 1 2 4.11 2 2 0 0 1 4 2h3a2 2 0 0 1 2 1.72c.12.9.33 1.78.62 2.63a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.45-1.2a2 2 0 0 1 2.11-.45c.85.29 1.73.5 2.63.62A2 2 0 0 1 22 16.92z" />
+  </svg>
+);
+
+const UserIcon = (
+  <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+    <path d="M20 21a8 8 0 1 0-16 0" />
+    <circle cx="12" cy="7" r="4" />
+  </svg>
+);

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  experimental: { typedRoutes: true },
+  images: { formats: ["image/avif", "image/webp"] }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "swiftsendmaxej",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "type-check": "tsc --noEmit"
+  },
+  "engines": { "node": ">=18.17" },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "sharp": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "latest",
+    "@types/react": "latest",
+    "autoprefixer": "latest",
+    "eslint": "latest",
+    "eslint-config-next": "latest",
+    "postcss": "latest",
+    "tailwindcss": "latest",
+    "typescript": "latest"
+  },
+  "browserslist": ["defaults", "not ie 11", "maintained node versions"]
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,135 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* ===== Root + Base (Zuck-clean, cosmic) ===== */
+:root {
+  --ss-orange: #ff7a18;
+  --ss-magenta: #d63cff;
+  --ss-gold: #f5c542;
+  --ss-bg1: #0c0a14;
+  --ss-bg2: #170b2d;
+  --ss-bg3: #110622;
+  --ease: cubic-bezier(.2,.8,.2,1);
+  --dur: 220ms;
+}
+
+html, body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  color: #f7f3ff;
+  font-family: theme(fontFamily.sans);
+  background:
+    radial-gradient(120% 140% at 10% -20%, rgba(255, 122, 24, 0.12) 0%, rgba(255, 122, 24, 0) 60%),
+    radial-gradient(140% 160% at 92% 120%, rgba(214, 60, 255, 0.16) 0%, rgba(214, 60, 255, 0) 62%),
+    linear-gradient(180deg, var(--ss-bg1) 0%, var(--ss-bg2) 50%, var(--ss-bg3) 100%);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.container {
+  width: min(1100px, calc(100% - clamp(36px, 10vw, 160px)));
+  margin-inline: auto;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  height: 1px; width: 1px;
+  overflow: hidden; clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap; border: 0; padding: 0; margin: -1px;
+}
+
+/* ===== Header styles (overlay, transparent, micro-fade) ===== */
+.ss-header{
+  position: absolute; inset: 0 0 auto 0;
+  z-index: 50; width: 100%;
+  background: transparent !important;
+  border: none;
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  transition: background var(--dur) var(--ease), border-color var(--dur) var(--ease);
+}
+.ss-header.header-fade{
+  background: linear-gradient(90deg, rgba(25,16,40,.035), rgba(100,28,102,.035)) !important;
+  border-bottom: 1px solid rgba(255,255,255,.045);
+}
+
+.header-row{
+  display:flex; align-items:center; justify-content:space-between;
+  padding: .75rem 0;
+}
+
+.brand{display:flex; align-items:center; gap:.6rem; color:#fff; text-decoration:none;}
+.brand-badge{
+  display:inline-grid; place-items:center; width:32px; aspect-ratio:1/1; border-radius:10px;
+  background: linear-gradient(135deg, var(--ss-orange) 0%, var(--ss-magenta) 80%);
+  box-shadow:0 0 18px rgba(214,60,255,.28); font-weight:800;
+}
+.brand-text{ font-weight:700; letter-spacing:.2px; }
+
+.nav-desktop{ display:none; gap:1.4rem; align-items:center; }
+@media (min-width:960px){ .nav-desktop{ display:flex } }
+
+.nav-desktop .nav-pill{
+  position:relative; display:inline-block; padding:0; margin:0; background:transparent; border-radius:0;
+  line-height:1; font-weight:500; letter-spacing:.05px; color:#f6f3fd;
+  transition: opacity var(--dur) var(--ease), transform var(--dur) var(--ease);
+  text-decoration: none;
+}
+.nav-desktop .nav-pill:hover{ opacity:.92; transform: translateY(-1px); }
+.nav-desktop .nav-pill::after{
+  content:""; position:absolute; left:0; right:0; bottom:-6px; height:2px; border-radius:999px;
+  background: linear-gradient(90deg, var(--ss-orange), var(--ss-magenta));
+  transform: scaleX(0); transform-origin: left;
+  transition: transform .32s var(--ease);
+}
+.nav-desktop .nav-pill:hover::after,
+.nav-desktop .nav-pill.is-active::after{ transform: scaleX(1); }
+
+.header-icons{ display:flex; align-items:center; gap:.6rem; }
+.icon-btn{
+  display:grid; place-items:center; width:36px; height:36px;
+  color:#f6f3fd; background:transparent; border-radius:8px; border:none; cursor:pointer;
+  transition: opacity var(--dur) var(--ease), transform var(--dur) var(--ease);
+}
+.icon-btn:hover{ opacity:.85; transform: translateY(-1px); }
+.icon-btn svg{ stroke:#ffffff; opacity:.95 }
+
+.hamburger{
+  display:inline-grid; gap:4px; margin-left:.25rem; width:38px; height:38px; place-items:center; border-radius:10px; background:transparent; border:none; cursor:pointer;
+}
+.hamburger span{ display:block; width:18px; height:2px; background:#fff; border-radius:3px }
+@media (min-width:960px){ .hamburger{ display:none } }
+
+.mobile-overlay[hidden]{ display:none }
+.mobile-overlay{
+  position:fixed; inset:8px; z-index:100; border-radius:24px; overflow:hidden;
+  background:
+    radial-gradient(1200px 800px at 20% 0%, rgba(214,60,255,.16), transparent 60%),
+    radial-gradient(1200px 800px at 100% 100%, rgba(255,122,24,.14), transparent 60%),
+    rgba(20,12,36,.56);
+  -webkit-backdrop-filter: blur(22px); backdrop-filter: blur(22px);
+  animation: fadeUp .28s var(--ease);
+  box-shadow: 0 10px 28px rgba(0,0,0,.28);
+}
+@keyframes fadeUp{ from{ opacity:0; transform: translateY(10px) } to{ opacity:1; transform:none } }
+
+.overlay-panel{ display:flex; flex-direction:column; height:100%; padding:14px }
+.overlay-top{ display:flex; align-items:center; justify-content:space-between }
+.overlay-close{
+  width:38px; height:38px; border-radius:12px; background:rgba(255,255,255,.08); color:#fff; font-size:18px; border:none; cursor:pointer;
+}
+.overlay-nav{ display:grid; gap:22px; place-content:center; text-align:center; height:100% }
+.overlay-nav a{
+  font-size:22px; font-weight:600; color:#fff; text-decoration:none; position:relative; letter-spacing:.1px;
+}
+.overlay-nav a::after{
+  content:""; position:absolute; left:50%; transform: translateX(-50%) scaleX(0); bottom:-8px; width:72px; height:2px; border-radius:999px;
+  background: linear-gradient(90deg, var(--ss-orange), var(--ss-magenta));
+  transition: transform .32s var(--ease);
+}
+.overlay-nav a:hover::after{ transform: translateX(-50%) scaleX(1) }
+.overlay-icons{ display:flex; align-items:center; justify-content:center; gap:.75rem; padding-bottom:12px }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,38 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./features/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}",
+    "./styles/**/*.{css}"
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui', 'SF Pro Text', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Arial', 'Noto Sans', 'Apple Color Emoji', 'Segoe UI Emoji']
+      },
+      colors: {
+        ss: {
+          bg1: "#0c0a14",
+          bg2: "#170b2d",
+          bg3: "#110622",
+          gold: "#f5c542",
+          orange: "#ff7a18",
+          magenta: "#d63cff",
+          lilac: "#b39ddb",
+          white: "#ffffff"
+        }
+      },
+      boxShadow: {
+        soft: "0 12px 28px rgba(214,60,255,.22)"
+      },
+      borderRadius: {
+        xl2: "1.25rem"
+      }
+    }
+  },
+  plugins: []
+};
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "es2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- align package, TypeScript, Tailwind, and Next.js configs with the SwiftSend baseline
- apply cosmic global styles and responsive header interactions to match the brand
- render the header from the site layout using the inlined client component implementation

## Testing
- npm install *(fails: registry access returned 403 for @types/node)*

------
https://chatgpt.com/codex/tasks/task_e_68e42d009b0c832fa8bcb0cc58d32641