### PR TITLE
chore: migrate Next config to mjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+const nextConfig = {
+  reactStrictMode: true,
+  typedRoutes: true,
+  images: {
+    formats: ["image/avif", "image/webp"],
+  },
+};
+
+export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  reactStrictMode: true,
-  typedRoutes: true,
-  images: { formats: ["image/avif", "image/webp"] }
-};
-
-export default nextConfig;


### PR DESCRIPTION
## Summary
- migrate the Next.js config file from TypeScript to ESM as required by Next 15.5
- preserve the existing strict mode, typed routes, and image format settings in the new config

## Testing
- npm run dev *(fails: next not found because dependencies are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b1df55cc832f949561c5e7468f59