### PR TITLE
Create animated SwiftSend footer component

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "../styles/globals.css";
 import type { Metadata } from "next";
 
 import Header from "../components/Header";
+import Footer from "@/components/footer/Footer";
 
 export const metadata: Metadata = {
   title: "SwiftSend",
@@ -19,6 +20,7 @@ export default function RootLayout({
       <body>
         <Header />
         <main>{children}</main>
+        <Footer />
       </body>
     </html>
   );

--- a/components/footer/Footer.module.css
+++ b/components/footer/Footer.module.css
@@ -1,0 +1,342 @@
+.root {
+  position: relative;
+  padding: clamp(52px, 6vw, 72px) 0 28px;
+  --dur: 300ms;
+  --ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+  background:
+    radial-gradient(960px 520px at 8% -18%, rgba(255, 150, 43, 0.12), transparent 60%),
+    radial-gradient(860px 560px at 90% 118%, rgba(214, 60, 255, 0.18), transparent 62%),
+    linear-gradient(180deg, rgba(16, 8, 32, 0.96) 0%, rgba(14, 5, 28, 0.98) 48%, rgba(12, 4, 24, 1) 100%);
+  color: #f5f0ff;
+}
+
+.root::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(255, 150, 43, 0.45), rgba(214, 60, 255, 0.5));
+  opacity: 0.75;
+  transform-origin: top;
+  pointer-events: none;
+}
+
+.inner {
+  width: min(1200px, calc(100% - clamp(36px, 10vw, 160px)));
+  margin: 0 auto clamp(32px, 4vw, 40px);
+  display: grid;
+  grid-template-columns: 1.2fr 1fr 1fr;
+  gap: clamp(20px, 4vw, 40px);
+  align-items: start;
+}
+
+@media (max-width: 960px) {
+  .inner {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .inner {
+    grid-template-columns: 1fr;
+    width: min(100%, calc(100% - 32px));
+  }
+}
+
+.footer__brand {
+  display: grid;
+  gap: 12px;
+  max-width: 320px;
+}
+
+.f-logo {
+  width: 60px;
+  height: 60px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #ff962b 0%, #d63cff 100%);
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  font-size: 28px;
+  box-shadow: 0 12px 28px rgba(214, 60, 255, 0.32);
+}
+
+.f-logo__grad {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(244, 236, 255, 0.55));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.f-name {
+  margin: 0;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+}
+
+.f-tag {
+  margin: 0;
+  font-weight: 600;
+  color: #f5c542;
+  font-size: 16px;
+}
+
+.f-desc {
+  margin: 0;
+  color: rgba(244, 236, 255, 0.7);
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.footer__links {
+  display: grid;
+  gap: 16px;
+}
+
+.f-colTitle {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: rgba(244, 236, 255, 0.9);
+}
+
+.f-cols {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px 18px;
+}
+
+.f-cols a {
+  color: rgba(244, 236, 255, 0.78);
+  font-size: 15px;
+  position: relative;
+  transition: color var(--dur) var(--ease);
+}
+
+.f-cols a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #ff962b, #d63cff);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.4s var(--ease);
+}
+
+.f-cols a:hover,
+.f-cols a:focus-visible {
+  color: #ffffff;
+}
+
+.f-cols a:hover::after,
+.f-cols a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.f-cols a:focus-visible {
+  outline: 2px solid rgba(244, 236, 255, 0.25);
+  outline-offset: 3px;
+}
+
+.footer__contact {
+  display: grid;
+  gap: 18px;
+}
+
+.f-connect {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+}
+
+.f-connect li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: center;
+  color: rgba(244, 236, 255, 0.78);
+  font-size: 15px;
+}
+
+.f-connect svg {
+  width: 28px;
+  height: 28px;
+  color: rgba(244, 236, 255, 0.6);
+}
+
+.f-connect a {
+  color: inherit;
+  position: relative;
+}
+
+.f-connect a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -3px;
+  height: 2px;
+  background: linear-gradient(90deg, #ff962b, #d63cff);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.4s var(--ease);
+}
+
+.f-connect a:hover::after,
+.f-connect a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.f-connect a:focus-visible {
+  outline: 2px solid rgba(244, 236, 255, 0.25);
+  outline-offset: 3px;
+}
+
+.f-social {
+  display: flex;
+  gap: 12px;
+}
+
+.f-icn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: linear-gradient(160deg, rgba(30, 16, 52, 0.82), rgba(16, 8, 34, 0.82));
+  color: #f5f0ff;
+  transition: transform var(--dur) var(--ease), box-shadow var(--dur) var(--ease), border-color var(--dur) var(--ease);
+  box-shadow: 0 10px 20px rgba(8, 2, 20, 0.28);
+}
+
+.f-icn span {
+  font-size: 18px;
+}
+
+.f-icn.is-hover,
+.f-icn:hover,
+.f-icn:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.28);
+  box-shadow: 0 16px 26px rgba(18, 8, 38, 0.34), inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.f-icn:focus-visible {
+  outline: 2px solid rgba(244, 236, 255, 0.32);
+  outline-offset: 3px;
+}
+
+.footer__bar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  width: min(1200px, calc(100% - clamp(36px, 10vw, 160px)));
+  margin: 0 auto;
+  padding-top: 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.f-copy {
+  margin: 0;
+  color: rgba(244, 236, 255, 0.6);
+  font-size: 14px;
+}
+
+.f-legal {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.f-legal a {
+  color: rgba(244, 236, 255, 0.7);
+  font-size: 14px;
+  transition: color var(--dur) var(--ease);
+}
+
+.f-legal a:hover,
+.f-legal a:focus-visible {
+  color: #ffffff;
+}
+
+.f-legal a:focus-visible {
+  outline: 2px solid rgba(244, 236, 255, 0.25);
+  outline-offset: 3px;
+}
+
+.root[data-anim-ready] .inner > *,
+.root[data-anim-ready] .footer__bar {
+  opacity: 0;
+  transform: translateY(18px);
+  transition: opacity 0.7s var(--ease), transform 0.7s var(--ease);
+}
+
+.root[data-anim-ready] .is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .f-icn,
+  .root[data-anim-ready] .inner > *,
+  .root[data-anim-ready] .footer__bar {
+    transition-duration: 0.01ms !important;
+  }
+
+  .root[data-anim-ready] .inner > *,
+  .root[data-anim-ready] .footer__bar {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}
+
+.underline-seq {
+  position: relative;
+  color: rgba(244, 236, 255, 0.7);
+  text-decoration: none;
+  transition: color var(--dur) var(--ease);
+}
+
+.underline-seq::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #ff962b, #d63cff);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.4s var(--ease);
+}
+
+.underline-seq:hover,
+.underline-seq:focus-visible {
+  color: #ffffff;
+}
+
+.underline-seq:hover::after,
+.underline-seq:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.underline-seq:focus-visible {
+  outline: 2px solid rgba(244, 236, 255, 0.25);
+  outline-offset: 3px;
+}

--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef } from "react";
+
+import styles from "./Footer.module.css";
+
+export interface FooterLink {
+  label: string;
+  href: string;
+  external?: boolean;
+}
+
+export interface FooterProps {
+  brandName?: string;
+  brandInitial?: string;
+  tagline?: string;
+  description?: string;
+  email?: string;
+  instagramHandle?: string;
+  instagramHref?: string;
+  quickLinks?: FooterLink[];
+  legalLinks?: FooterLink[];
+  className?: string;
+}
+
+const DEFAULT_BRAND_NAME = "SwiftSend";
+const DEFAULT_BRAND_INITIAL = "S";
+const DEFAULT_TAGLINE = "Never Stay Satisfied.";
+const DEFAULT_DESCRIPTION = "Building the future of digital solutions, one project at a time.";
+const DEFAULT_EMAIL = "hello@swiftsend.dev";
+const DEFAULT_INSTAGRAM_HANDLE = "@swiftsend.dev";
+const DEFAULT_INSTAGRAM_HREF = "https://instagram.com/swiftsend.dev";
+
+const DEFAULT_QUICK_LINKS: FooterLink[] = [
+  { label: "Home", href: "#home" },
+  { label: "Work", href: "#portfolio" },
+  { label: "Packs", href: "#packs" },
+  { label: "Contact", href: "#contact" },
+  { label: "Services", href: "#services" },
+  { label: "Labs", href: "#labs" },
+  { label: "About", href: "#about" },
+];
+
+const DEFAULT_LEGAL_LINKS: FooterLink[] = [
+  { label: "Privacy Policy", href: "#" },
+  { label: "Terms of Service", href: "#" },
+];
+
+const combineClassNames = (...values: Array<string | undefined>): string =>
+  values.filter(Boolean).join(" ");
+
+const Footer = ({
+  brandName = DEFAULT_BRAND_NAME,
+  brandInitial = DEFAULT_BRAND_INITIAL,
+  tagline = DEFAULT_TAGLINE,
+  description = DEFAULT_DESCRIPTION,
+  email = DEFAULT_EMAIL,
+  instagramHandle = DEFAULT_INSTAGRAM_HANDLE,
+  instagramHref = DEFAULT_INSTAGRAM_HREF,
+  quickLinks = DEFAULT_QUICK_LINKS,
+  legalLinks = DEFAULT_LEGAL_LINKS,
+  className,
+}: FooterProps) => {
+  const rootRef = useRef<HTMLElement | null>(null);
+  const currentYear = new Date().getFullYear();
+
+  useEffect(() => {
+    const node = rootRef.current;
+    if (!node) {
+      return;
+    }
+
+    node.dataset.animReady = "true";
+
+    const animatedElements = Array.from(
+      node.querySelectorAll<HTMLElement>("[data-animate='true']")
+    );
+
+    if (animatedElements.length === 0) {
+      return;
+    }
+
+    const visibleClass = styles["is-visible"];
+    if (!visibleClass) {
+      return;
+    }
+
+    const applyVisibility = (isVisible: boolean) => {
+      animatedElements.forEach((element) => {
+        if (isVisible) {
+          element.classList.add(visibleClass);
+        } else {
+          element.classList.remove(visibleClass);
+        }
+      });
+    };
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    let observer: IntersectionObserver | null = null;
+
+    const disconnectObserver = () => {
+      observer?.disconnect();
+      observer = null;
+    };
+
+    const observe = () => {
+      disconnectObserver();
+      observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            applyVisibility(entry.isIntersecting);
+          });
+        },
+        { threshold: 0.25 }
+      );
+      observer.observe(node);
+    };
+
+    if (mediaQuery.matches) {
+      applyVisibility(true);
+    } else {
+      applyVisibility(false);
+      observe();
+    }
+
+    const handleMediaChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        disconnectObserver();
+        applyVisibility(true);
+      } else {
+        applyVisibility(false);
+        observe();
+      }
+    };
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleMediaChange);
+    } else {
+      mediaQuery.addListener(handleMediaChange);
+    }
+
+    return () => {
+      disconnectObserver();
+      if (typeof mediaQuery.removeEventListener === "function") {
+        mediaQuery.removeEventListener("change", handleMediaChange);
+      } else {
+        mediaQuery.removeListener(handleMediaChange);
+      }
+    };
+  }, []);
+
+  const renderLink = (link: FooterLink, linkClassName?: string) => {
+    const { href, label } = link;
+    const isExternal = link.external ?? /^https?:\/\//.test(href);
+
+    if (isExternal) {
+      return (
+        <a
+          key={`${label}-${href}`}
+          href={href}
+          className={linkClassName}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {label}
+        </a>
+      );
+    }
+
+    if (href.startsWith("/")) {
+      return (
+        <Link key={`${label}-${href}`} href={href} className={linkClassName}>
+          {label}
+        </Link>
+      );
+    }
+
+    return (
+      <a key={`${label}-${href}`} href={href} className={linkClassName}>
+        {label}
+      </a>
+    );
+  };
+
+  const rootClassName = combineClassNames(styles.root, className);
+
+  return (
+    <footer ref={rootRef} className={rootClassName} data-footer>
+      <div className={styles.inner}>
+        <section className={styles["footer__brand"]} data-animate="true">
+          <span className={styles["f-logo"]} aria-hidden="true">
+            <span className={styles["f-logo__grad"]}>{brandInitial}</span>
+          </span>
+          <h3 className={styles["f-name"]}>{brandName}</h3>
+          {tagline ? <p className={styles["f-tag"]}>{tagline}</p> : null}
+          {description ? <p className={styles["f-desc"]}>{description}</p> : null}
+        </section>
+
+        <nav className={styles["footer__links"]} aria-label="Quick Links" data-animate="true">
+          <h4 className={styles["f-colTitle"]}>Quick Links</h4>
+          <ul className={styles["f-cols"]}>
+            {quickLinks.map((link) => (
+              <li key={`${link.label}-${link.href}`}>
+                {renderLink(link)}
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        <section className={styles["footer__contact"]} aria-label="Connect" data-animate="true">
+          <h4 className={styles["f-colTitle"]}>Connect</h4>
+          <ul className={styles["f-connect"]}>
+            <li>
+              <svg viewBox="0 0 24 24" aria-hidden="true" role="img">
+                <path fill="currentColor" d="M4 4h16v16H4z" opacity="0.08" />
+                <path fill="currentColor" d="M4 6l8 5 8-5v12H4z" />
+                <path fill="currentColor" d="M20 6H4l8 5z" />
+              </svg>
+              <a href={`mailto:${email}`}>{email}</a>
+            </li>
+            <li>
+              <svg viewBox="0 0 24 24" aria-hidden="true" role="img">
+                <path
+                  fill="currentColor"
+                  d="M7 2h10a5 5 0 015 5v10a5 5 0 01-5 5H7a5 5 0 01-5-5V7a5 5 0 015-5z"
+                  opacity="0.08"
+                />
+                <circle cx="12" cy="12" r="3" fill="currentColor" />
+              </svg>
+              {instagramHref ? (
+                <a href={instagramHref} target="_blank" rel="noopener noreferrer">
+                  {instagramHandle}
+                </a>
+              ) : (
+                <span>{instagramHandle}</span>
+              )}
+            </li>
+          </ul>
+
+          <div className={styles["f-social"]}>
+            <a
+              className={styles["f-icn"]}
+              aria-label="Email"
+              href={`mailto:${email}`}
+            >
+              <span>✉️</span>
+            </a>
+            {instagramHref ? (
+              <a
+                className={styles["f-icn"]}
+                aria-label="Instagram"
+                href={instagramHref}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span>◎</span>
+              </a>
+            ) : null}
+          </div>
+        </section>
+      </div>
+
+      <div className={styles["footer__bar"]} data-animate="true">
+        <p className={styles["f-copy"]}>© {currentYear} {brandName}. All Rights Reserved.</p>
+        <nav className={styles["f-legal"]} aria-label="Legal">
+          {legalLinks.map((link) =>
+            renderLink(link, styles["underline-seq"])
+          )}
+        </nav>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,12 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- add a reusable, animated SwiftSend footer component with customizable branding, links, and contact details
- port the legacy footer styles into a scoped CSS module while preserving visual fidelity and motion behavior
- wire the footer into the root layout and configure TypeScript path aliases for module imports

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e5a8ca3cac832f9bf04f7bdd3a0e1a