### PR TITLE
feat: implement SwiftSend Max 3.0 hero section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,260 @@
+"use client";
+
+import { useEffect } from "react";
+
 // SwiftSend: placeholder scaffold added 2025-10-07T23:34:08Z — real implementation to follow
 export default function HomePage() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const canvas = document.getElementById("fx-stars") as HTMLCanvasElement | null;
+    if (!canvas) return;
+
+    const context = canvas.getContext("2d");
+    if (!context) return;
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    let isReduced = mediaQuery.matches;
+
+    type Star = {
+      x: number;
+      y: number;
+      radius: number;
+      baseAlpha: number;
+      twinkleSpeed: number;
+      offset: number;
+    };
+
+    let stars: Star[] = [];
+    let animationFrameId: number | null = null;
+    let resizeTimer: number | undefined;
+
+    const generateStars = (width: number, height: number) => {
+      const starTotal = 160;
+      stars = Array.from({ length: starTotal }, () => ({
+        x: Math.random() * width,
+        y: Math.random() * height,
+        radius: Math.random() * 1.2 + 0.3,
+        baseAlpha: 0.2 + Math.random() * 0.4,
+        twinkleSpeed: 0.002 + Math.random() * 0.003,
+        offset: Math.random() * Math.PI * 2,
+      }));
+    };
+
+    const setCanvasSize = () => {
+      const { innerWidth, innerHeight } = window;
+      const dpr = window.devicePixelRatio || 1;
+
+      canvas.width = innerWidth * dpr;
+      canvas.height = innerHeight * dpr;
+      canvas.style.width = `${innerWidth}px`;
+      canvas.style.height = `${innerHeight}px`;
+      context.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+      generateStars(innerWidth, innerHeight);
+    };
+
+    const drawFrame = (time: number) => {
+      context.clearRect(0, 0, canvas.width, canvas.height);
+
+      stars.forEach((star) => {
+        const alpha = isReduced
+          ? star.baseAlpha
+          : star.baseAlpha + Math.sin(time * star.twinkleSpeed + star.offset) * 0.25;
+        context.globalAlpha = Math.min(1, Math.max(0.1, alpha));
+        context.beginPath();
+        context.arc(star.x, star.y, star.radius, 0, Math.PI * 2);
+        context.fillStyle = "#f4f0ff";
+        context.fill();
+      });
+
+      context.globalAlpha = 1;
+    };
+
+    const startAnimation = () => {
+      if (isReduced) {
+        drawFrame(performance.now());
+        return;
+      }
+
+      const render = (timestamp: number) => {
+        drawFrame(timestamp);
+        animationFrameId = window.requestAnimationFrame(render);
+      };
+
+      animationFrameId = window.requestAnimationFrame(render);
+    };
+
+    const stopAnimation = () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+        animationFrameId = null;
+      }
+    };
+
+    const handleResize = () => {
+      if (resizeTimer) {
+        window.clearTimeout(resizeTimer);
+      }
+
+      resizeTimer = window.setTimeout(() => {
+        setCanvasSize();
+        if (isReduced) {
+          drawFrame(performance.now());
+        }
+      }, 180);
+    };
+
+    const handleMotionChange = (event: MediaQueryListEvent) => {
+      isReduced = event.matches;
+      stopAnimation();
+      if (isReduced) {
+        drawFrame(performance.now());
+      } else {
+        startAnimation();
+      }
+    };
+
+    setCanvasSize();
+    startAnimation();
+
+    window.addEventListener("resize", handleResize);
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleMotionChange);
+    } else {
+      mediaQuery.addListener(handleMotionChange);
+    }
+
+    return () => {
+      stopAnimation();
+      window.removeEventListener("resize", handleResize);
+      if (resizeTimer) {
+        window.clearTimeout(resizeTimer);
+      }
+      if (typeof mediaQuery.removeEventListener === "function") {
+        mediaQuery.removeEventListener("change", handleMotionChange);
+      } else {
+        mediaQuery.removeListener(handleMotionChange);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const field = document.querySelector<HTMLDivElement>(".spark-field");
+    if (!field) return;
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    let isReduced = mediaQuery.matches;
+
+    const generateSparks = () => {
+      field.innerHTML = "";
+
+      const total = 36;
+      for (let i = 0; i < total; i += 1) {
+        const spark = document.createElement("span");
+        spark.className = "spark";
+
+        if (Math.random() < 0.22) {
+          spark.classList.add(Math.random() < 0.5 ? "purple" : "orange");
+        }
+
+        spark.style.setProperty("--l", `${(Math.random() * 100).toFixed(2)}%`);
+        spark.style.setProperty("--t", `${(Math.random() * 100).toFixed(2)}%`);
+        spark.style.setProperty("--sz", `${(Math.random() * 6 + 2).toFixed(2)}px`);
+
+        const floatDuration = (Math.random() * 4 + 6).toFixed(2);
+        const twinkleDuration = (Math.random() * 2 + 3).toFixed(2);
+        const amplitude = (Math.random() * 18 + 6).toFixed(2);
+        const delayOne = (Math.random() * 6).toFixed(2);
+        const delayTwo = (Math.random() * 5).toFixed(2);
+
+        spark.style.setProperty("--dur", isReduced ? "0s" : `${floatDuration}s`);
+        spark.style.setProperty("--tw", isReduced ? "0s" : `${twinkleDuration}s`);
+        spark.style.setProperty("--amp", isReduced ? "0px" : `${amplitude}px`);
+        spark.style.setProperty("--d1", isReduced ? "0s" : `${delayOne}s`);
+        spark.style.setProperty("--d2", isReduced ? "0s" : `${delayTwo}s`);
+
+        if (isReduced) {
+          spark.style.setProperty("--spark-opacity", `${(0.3 + Math.random() * 0.4).toFixed(2)}`);
+        }
+
+        field.appendChild(spark);
+      }
+    };
+
+    const handleMotionChange = (event: MediaQueryListEvent) => {
+      isReduced = event.matches;
+      generateSparks();
+    };
+
+    generateSparks();
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleMotionChange);
+    } else {
+      mediaQuery.addListener(handleMotionChange);
+    }
+
+    return () => {
+      field.innerHTML = "";
+      if (typeof mediaQuery.removeEventListener === "function") {
+        mediaQuery.removeEventListener("change", handleMotionChange);
+      } else {
+        mediaQuery.removeListener(handleMotionChange);
+      }
+    };
+  }, []);
+
   return (
     <>
       <section id="home" data-hero className="hero">
-        <h1>SwiftSend is gearing up for launch</h1>
-        <p>
-          Our team is preparing a full-service delivery of software, data, and automation. This
-          temporary canvas helps confirm the foundation before the real experience arrives.
-        </p>
-        <button type="button" className="cta-button">
-          Coming Soon
-        </button>
+        <canvas id="fx-stars" aria-hidden="true" />
+        <div className="spark-field" data-spark-field aria-hidden="true" />
+        <div className="hero-inner">
+          <div className="tile-wrap" aria-hidden="true">
+            <div className="tile">
+              <span className="tile-s">s</span>
+              <span className="orbit o1" />
+              <span className="orbit o2" />
+              <span className="orbit o3" />
+            </div>
+          </div>
+          <h1 className="display">
+            Your Software.
+            <br />
+            <span className="grad-word">Your</span> Stack.
+            <br />
+            Your Savings.
+          </h1>
+          <p className="lede">
+            SwiftSend Max 3.0 powers ambitious builders with a battle-tested engineering core,
+            product accelerators, and a crew obsessed with velocity and polish.
+          </p>
+          <div className="cta">
+            <a href="#contact" className="btn btn-primary">
+              Start a Build
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                width="18"
+                height="18"
+                viewBox="0 0 18 18"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M4 9h8.586l-2.793-2.793L10.5 5.5 15 10l-4.5 4.5-0.707-0.707L12.586 10H4V9z"
+                  fill="currentColor"
+                />
+              </svg>
+            </a>
+            <a href="#portfolio" className="btn btn-ghost underline-seq">
+              See Our Work
+            </a>
+          </div>
+        </div>
       </section>
       <section id="about" className="section-shell">
         <h2>About SwiftSend</h2>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -191,44 +191,6 @@ main {
   display: block;
 }
 
-.hero {
-  min-height: 480px;
-  display: grid;
-  gap: 1.5rem;
-  place-content: center;
-  text-align: center;
-  padding: clamp(3rem, 10vw, 6rem) 1.5rem;
-}
-
-.hero h1 {
-  font-size: clamp(2.5rem, 6vw, 3.75rem);
-  font-weight: 700;
-  margin: 0;
-}
-
-.hero p {
-  font-size: clamp(1.05rem, 3vw, 1.3rem);
-  margin: 0;
-  max-width: 42rem;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.hero .cta-button {
-  justify-self: center;
-  margin-top: 1rem;
-  padding: 0.85rem 1.75rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.08);
-  transition: transform 160ms ease, box-shadow 160ms ease;
-}
-
-.hero .cta-button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.18);
-}
-
 .section-shell {
   padding: clamp(3rem, 9vw, 5rem) 1.5rem;
 }
@@ -241,5 +203,343 @@ main {
 .section-shell p {
   max-width: 48rem;
   margin: 0;
+}
+
+/* ===========================
+   SwiftSend Max 3.0 — Hero (Home)
+   =========================== */
+.hero {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  padding: 0 1.5rem;
+  overflow: hidden;
+  color: rgba(250, 246, 255, 0.96);
+  background:
+    radial-gradient(1200px 800px at 10% -8%, rgba(148, 61, 211, 0.18), transparent 60%),
+    radial-gradient(1200px 800px at 96% 106%, rgba(255, 122, 24, 0.18), transparent 60%),
+    linear-gradient(180deg, #2b154b 0%, #4d2a92 50%, #a24a5e 100%);
+}
+
+#fx-stars {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.spark-field {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.spark {
+  position: absolute;
+  left: var(--l);
+  top: var(--t);
+  width: var(--sz);
+  height: var(--sz);
+  border-radius: 999px;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0));
+  box-shadow: 0 0 18px rgba(255, 255, 255, 0.35);
+  opacity: var(--spark-opacity, 0.72);
+  animation:
+    spark-float var(--dur) ease-in-out var(--d1) infinite alternate,
+    spark-twinkle var(--tw) ease-in-out var(--d2) infinite alternate;
+}
+
+.spark.purple {
+  box-shadow: 0 0 22px rgba(153, 71, 255, 0.65);
+}
+
+.spark.orange {
+  box-shadow: 0 0 22px rgba(255, 140, 78, 0.55);
+}
+
+.hero-inner {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: min(1200px, calc(100% - 32px));
+  padding: 8vh 0 12vh;
+  text-align: center;
+  gap: 1.1rem;
+}
+
+.tile-wrap {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: clamp(2.6rem, 6vw, 3.8rem);
+}
+
+.tile {
+  position: relative;
+  width: clamp(120px, 18vw, 160px);
+  height: clamp(120px, 18vw, 160px);
+  border-radius: 28px;
+  background: linear-gradient(140deg, rgba(255, 122, 24, 0.85) 0%, rgba(214, 60, 255, 0.92) 65%, rgba(122, 92, 255, 0.95) 100%);
+  box-shadow:
+    0 26px 48px rgba(17, 5, 34, 0.45),
+    inset 0 0 20px rgba(255, 255, 255, 0.18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: tile-bob 6s ease-in-out infinite;
+}
+
+.tile-s {
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+  font-weight: 700;
+  font-size: clamp(3rem, 7vw, 4.75rem);
+  letter-spacing: -0.05em;
+  color: rgba(255, 255, 255, 0.92);
+  text-transform: lowercase;
+}
+
+.orbit {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: clamp(10px, 2vw, 14px);
+  height: clamp(10px, 2vw, 14px);
+  margin: calc(clamp(10px, 2vw, 14px) / -2) 0 0 calc(clamp(10px, 2vw, 14px) / -2);
+  border-radius: 50%;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.95) 0%, rgba(214, 60, 255, 0.65) 100%);
+  box-shadow: 0 0 20px rgba(214, 60, 255, 0.55);
+  opacity: 0.9;
+}
+
+.o1 {
+  animation: orb1 18s linear infinite;
+}
+
+.o2 {
+  animation: orb2 14s linear infinite;
+}
+
+.o3 {
+  animation: orb3 22s linear infinite;
+}
+
+.display {
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  font-size: clamp(40px, 6vw, 76px);
+  line-height: 1.08;
+  margin: 0 0 0.4rem;
+}
+
+.grad-word {
+  background: linear-gradient(135deg, #ff7a18 0%, #d63cff 60%, #7a5cff 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.lede {
+  max-width: 80ch;
+  margin: 0 auto;
+  font-size: clamp(16px, 2.2vw, 20px);
+  color: rgba(247, 242, 255, 0.86);
+}
+
+.cta {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+  justify-content: center;
+  margin-top: 18px;
+  flex-wrap: wrap;
+}
+
+.btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  padding: 0.9rem 1.7rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 180ms ease, box-shadow 220ms ease, filter 220ms ease;
+  will-change: transform, box-shadow;
+}
+
+.btn svg {
+  width: 1rem;
+  height: 1rem;
+  margin-left: 0.25rem;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #ff7a18 0%, #d63cff 60%, #7a5cff 100%);
+  box-shadow: 0 0 28px rgba(214, 60, 255, 0.4);
+  color: #fff;
+}
+
+.btn-primary:hover,
+.btn-primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow:
+    0 8px 24px rgba(214, 60, 255, 0.45),
+    0 0 34px rgba(255, 122, 24, 0.45),
+    0 0 18px rgba(122, 92, 255, 0.4);
+}
+
+.btn-primary:active {
+  transform: translateY(-1px);
+}
+
+.btn-ghost {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  box-shadow: 0 10px 24px rgba(16, 7, 35, 0.35);
+}
+
+.btn-ghost:hover,
+.btn-ghost:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 28px rgba(16, 7, 35, 0.45);
+}
+
+.underline-seq {
+  position: relative;
+}
+
+.underline-seq::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -4px;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.75);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 200ms ease;
+}
+
+.underline-seq:hover::after,
+.underline-seq:focus-visible::after {
+  transform: scaleX(1);
+}
+
+@keyframes tile-bob {
+  0%,
+  100% {
+    transform: translate3d(0, -6px, 0);
+  }
+
+  50% {
+    transform: translate3d(0, 8px, 0);
+  }
+}
+
+@keyframes orb1 {
+  from {
+    transform: rotate(0deg) translateX(64px);
+  }
+
+  to {
+    transform: rotate(360deg) translateX(64px);
+  }
+}
+
+@keyframes orb2 {
+  from {
+    transform: rotate(0deg) translateX(52px);
+  }
+
+  to {
+    transform: rotate(360deg) translateX(52px);
+  }
+}
+
+@keyframes orb3 {
+  from {
+    transform: rotate(0deg) translateX(74px);
+  }
+
+  to {
+    transform: rotate(360deg) translateX(74px);
+  }
+}
+
+@keyframes spark-float {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+
+  to {
+    transform: translate3d(0, calc(-1 * var(--amp)), 0);
+  }
+}
+
+@keyframes spark-twinkle {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+
+  45% {
+    opacity: 0.85;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero-inner {
+    padding-bottom: 14vh;
+    gap: 0.95rem;
+  }
+
+  .cta {
+    gap: 14px;
+  }
+
+  .btn {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tile,
+  .o1,
+  .o2,
+  .o3,
+  .spark,
+  .btn-primary,
+  .btn-ghost {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    transform: none !important;
+  }
+
+  .tile {
+    animation: none;
+  }
+
+  .o1,
+  .o2,
+  .o3 {
+    animation: none;
+  }
+
+  .spark {
+    animation: none;
+  }
 }
 


### PR DESCRIPTION
## Summary
- replace the home hero with the SwiftSend Max 3.0 layout featuring the gradient tile, new headline copy, and dual CTAs
- add React effects that render the animated starfield canvas and spark particles with resize and reduced-motion safeguards
- extend global styles with gradient backgrounds, button treatments, orbit animations, and responsive/reduced-motion rules for the hero

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e5fcd672b4832f93d10c583b8fe2ea