### PR TITLE
Implement interactive Labs section

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ status: "ok" });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Labs from "@/features/labs/LabsGlow";
 import { useEffect, type CSSProperties } from "react";
 
 // SwiftSend: placeholder scaffold added 2025-10-07T23:34:08Z — real implementation to follow
@@ -271,13 +272,7 @@ export default function HomePage() {
           is finalized.
         </p>
       </section>
-      <section id="labs" className="section-shell">
-        <h2>Labs</h2>
-        <p>
-          Labs will showcase SwiftSend experiments, prototypes, and research snapshots for early
-          feedback.
-        </p>
-      </section>
+      <Labs />
       <section id="packs" className="section-shell">
         <h2>Packs</h2>
         <p>

--- a/features/labs/LabsGlow.tsx
+++ b/features/labs/LabsGlow.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+
+/**
+ * SwiftSend — Labs Section (TSX)
+ * - Reveal-on-view for items
+ * - Starfield builder (CSS-powered twinkles)
+ * - Parallax glow orb on scroll (desktop only)
+ * - “Comet rail” micro animation on hover / first reveal
+ * - Reduced-motion safe
+ *
+ * NOTE: Only edits to this existing file. No new files created.
+ */
+
+type LabsItem = {
+  id: string;
+  title: string;
+  blurb: string;
+  status: "Beta" | "Live" | "Coming Soon" | "Prototype";
+  accent: "orange" | "green" | "cyan" | "purple" | "rose" | "blueCyan";
+  statusClass:
+    | "labs-status--beta"
+    | "labs-status--live"
+    | "labs-status--coming"
+    | "labs-status--prototype"
+    | "labs-status--beta-alt";
+  href: string;
+  icon: string; // inline SVG string
+};
+
+export default function Labs() {
+  const sectionRef = useRef<HTMLElement | null>(null);
+  const gridRef = useRef<HTMLUListElement | null>(null);
+  const starsRef = useRef<HTMLDivElement | null>(null);
+  const orbRef = useRef<HTMLDivElement | null>(null);
+
+  const isBrowser = typeof window !== "undefined";
+  const items: LabsItem[] = useMemo(
+    () => [
+      {
+        id: "swiftpay-mini",
+        title: "SwiftPay Mini",
+        blurb: "One-page checkout links with auto receipts.",
+        status: "Beta",
+        accent: "orange",
+        statusClass: "labs-status--beta",
+        href: "#",
+        icon: `<svg viewBox="0 0 32 32" aria-hidden="true"><rect x="5.5" y="7.5" width="21" height="13" rx="2.6" ry="2.6"></rect><path d="M5 13.5h22"></path><path d="M10.5 17h6" stroke-linecap="round"></path><path d="M8.5 22.5h6.5" stroke-linecap="round"></path></svg>`,
+      },
+      {
+        id: "site-in-a-day",
+        title: "Site-in-a-Day",
+        blurb: "Flat-rate, brand-colored sites shipped fast.",
+        status: "Live",
+        accent: "green",
+        statusClass: "labs-status--live",
+        href: "#",
+        icon: `<svg viewBox="0 0 32 32" aria-hidden="true"><rect x="5" y="6.5" width="22" height="18" rx="3" ry="3"></rect><path d="M5 12.5h22"></path><path d="M11 18.5h6" stroke-linecap="round"></path><path d="M11 22.5h10" stroke-linecap="round"></path></svg>`,
+      },
+      {
+        id: "fee-optimizer",
+        title: "Fee Optimizer Widget",
+        blurb: `"Pay by Bank & save" nudges + estimator.`,
+        status: "Coming Soon",
+        accent: "cyan",
+        statusClass: "labs-status--coming",
+        href: "#",
+        icon: `<svg viewBox="0 0 32 32" aria-hidden="true"><circle cx="16" cy="16" r="9"></circle><path d="M16 10v12" stroke-linecap="round"></path><path d="M12 14h8" stroke-linecap="round"></path><path d="M12 18h4" stroke-linecap="round"></path></svg>`,
+      },
+      {
+        id: "leads-autopilot",
+        title: "Leads Autopilot",
+        blurb: "Form → CRM → AI triage → calendar booking.",
+        status: "Beta",
+        accent: "purple",
+        statusClass: "labs-status--beta",
+        href: "#",
+        icon: `<svg viewBox="0 0 32 32" aria-hidden="true"><path d="M8.5 9.5h15" stroke-linecap="round"></path><path d="M8.5 15.5h10" stroke-linecap="round"></path><path d="M8.5 21.5h5.5" stroke-linecap="round"></path><path d="M21 15.5 24.5 19l-3.5 3.5" stroke-linecap="round"></path></svg>`,
+      },
+      {
+        id: "doc-copilot",
+        title: "Doc Copilot",
+        blurb: "PDFs into Q&A bots with citations.",
+        status: "Prototype",
+        accent: "rose",
+        statusClass: "labs-status--prototype",
+        href: "#",
+        icon: `<svg viewBox="0 0 32 32" aria-hidden="true"><path d="M11 6.5h9.5L25.5 12v13.5H11z"></path><path d="M20 6.5v6h6" stroke-linecap="round"></path><path d="M14 16.5h8" stroke-linecap="round"></path><path d="M14 20.5h5" stroke-linecap="round"></path></svg>`,
+      },
+      {
+        id: "site-health-monitor",
+        title: "Site Health Monitor",
+        blurb: "Uptime + Lighthouse snapshots with alerts.",
+        status: "Beta",
+        accent: "blueCyan",
+        statusClass: "labs-status--beta-alt",
+        href: "#",
+        icon: `<svg viewBox="0 0 32 32" aria-hidden="true"><path d="M6.5 22.5 11 14.5l4 7 4.5-10 5 11" stroke-linecap="round"></path><path d="M6 25.5h20" stroke-linecap="round"></path><path d="M7.5 9.5h17" stroke-linecap="round"></path></svg>`,
+      },
+    ],
+    []
+  );
+
+  // Reveal-on-view & dynamic build
+  useEffect(() => {
+    const section = sectionRef.current;
+    if (!isBrowser || !section) return;
+
+    document.body.classList.add("is-labs-js");
+
+    // Build cards
+    const grid = gridRef.current!;
+    if (grid && !grid.hasChildNodes()) {
+      const frag = document.createDocumentFragment();
+      items.forEach((item, idx) => {
+        const li = document.createElement("li");
+        li.className = `labs-card labs-card--${item.accent}`;
+        li.setAttribute("role", "article");
+        li.dataset.reveal = "";
+        li.dataset.revealIndex = String(idx + 2);
+
+        const status = document.createElement("span");
+        status.className = `labs-status ${item.statusClass}`;
+        status.textContent = item.status;
+
+        const iconWrap = document.createElement("div");
+        iconWrap.className = "labs-icon";
+        iconWrap.innerHTML = item.icon;
+        iconWrap.setAttribute("aria-hidden", "true");
+
+        const body = document.createElement("div");
+        body.className = "labs-card-body";
+
+        const h3 = document.createElement("h3");
+        h3.className = "labs-card-title";
+        h3.textContent = item.title;
+
+        const p = document.createElement("p");
+        p.className = "labs-card-blurb";
+        p.textContent = item.blurb;
+
+        const cta = document.createElement("a");
+        cta.className = "labs-cta";
+        cta.href = item.href;
+        cta.textContent = "Learn More";
+
+        const rail = document.createElement("div");
+        rail.className = "labs-rail labs-rail--comet";
+
+        body.append(h3, p, cta, rail);
+        li.append(iconWrap, status, body);
+        frag.appendChild(li);
+      });
+      grid.appendChild(frag);
+    }
+
+    // Build twinkle points once
+    const stars = starsRef.current!;
+    if (stars && !stars.dataset.built) {
+      const desktop = window.matchMedia("(min-width: 768px)").matches;
+      const starCount = (desktop ? 60 : 30) + Math.floor(Math.random() * 40);
+      const glowCount = (desktop ? 10 : 6) + Math.floor(Math.random() * 10);
+      const make = (cls: string, style: Record<string, string>) => {
+        const el = document.createElement("span");
+        el.className = cls;
+        Object.entries(style).forEach(([k, v]) => el.style.setProperty(k, v));
+        stars.appendChild(el);
+      };
+      const rand = (a: number, b: number) => Math.random() * (b - a) + a;
+
+      for (let i = 0; i < starCount; i++) {
+        make("labs-star", {
+          "--left": `${rand(-4, 104).toFixed(2)}%`,
+          "--top": `${rand(-6, 106).toFixed(2)}%`,
+          "--size": `${rand(1, 2.2).toFixed(2)}px`,
+          "--twinkle-duration": `${rand(2.5, 5).toFixed(2)}s`,
+          "--twinkle-delay": `${rand(0, 3).toFixed(2)}s`,
+          "--twinkle-min": rand(0.32, 0.52).toFixed(2),
+          "--twinkle-max": rand(0.65, 0.95).toFixed(2),
+        });
+      }
+      for (let i = 0; i < glowCount; i++) {
+        make("labs-glow", {
+          "--left": `${rand(-8, 108).toFixed(2)}%`,
+          "--top": `${rand(-12, 112).toFixed(2)}%`,
+          "--size": `${rand(3.2, 6.4).toFixed(2)}px`,
+          "--twinkle-duration": `${rand(3, 5.4).toFixed(2)}s`,
+          "--twinkle-delay": `${rand(0, 3).toFixed(2)}s`,
+          "--twinkle-min": rand(0.18, 0.32).toFixed(2),
+          "--twinkle-max": rand(0.5, 0.78).toFixed(2),
+          "--blur": `${rand(4, 8).toFixed(2)}px`,
+        });
+      }
+      stars.dataset.built = "true";
+    }
+
+    // Reveal-on-view + comet trigger
+    const revealEls = Array.from(section.querySelectorAll<HTMLElement>("[data-reveal]"));
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const seen = new WeakSet<Element>();
+    const cooldown = new WeakMap<Element, number>();
+    const canComet = () => !reduced;
+    const playComet = (rail: Element | null) => {
+      if (!rail || !canComet()) return;
+      rail.classList.remove("is-playing");
+      requestAnimationFrame(() => rail.classList.add("is-playing"));
+    };
+
+    if ("IntersectionObserver" in window) {
+      const io = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((e) => {
+            if (!e.isIntersecting || seen.has(e.target)) return;
+            seen.add(e.target);
+            const idx = Number((e.target as HTMLElement).dataset.revealIndex || 0);
+            const delay = Math.min(80 + idx * 20, 220);
+            setTimeout(() => {
+              (e.target as HTMLElement).classList.add("is-in");
+              if ((e.target as HTMLElement).classList.contains("labs-card")) {
+                const rail = e.target.querySelector(".labs-rail--comet");
+                const now = performance.now();
+                if ((cooldown.get(e.target) ?? 0) + 1500 < now) {
+                  cooldown.set(e.target, now);
+                  playComet(rail);
+                }
+              }
+            }, delay);
+            io.unobserve(e.target);
+          });
+        },
+        { threshold: 0.3, rootMargin: "0px 0px -10%" }
+      );
+      revealEls.forEach((el) => io.observe(el));
+    } else {
+      revealEls.forEach((el) => el.classList.add("is-in"));
+    }
+
+    // Parallax orb (desktop only)
+    const orb = orbRef.current;
+    let raf: number | null = null;
+    const desktopMQ = window.matchMedia("(min-width: 768px)");
+    const reducedMQ = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    const tick = () => {
+      raf = null;
+      if (!orb) return;
+      const allow = desktopMQ.matches && !reducedMQ.matches;
+      if (!allow) {
+        orb.style.transform = "translate3d(0,0,0)";
+        return;
+      }
+      const rect = section.getBoundingClientRect();
+      const vh = window.innerHeight || 1;
+      const progress = Math.min(Math.max(1 - (rect.top + rect.height * 0.5) / (vh + rect.height), -1), 1);
+      const y = Math.max(Math.min(progress * 12, 10), -10);
+      const x = Math.max(Math.min(progress * 6, 5), -5);
+      orb.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+    };
+    const req = () => {
+      if (raf != null) return;
+      raf = requestAnimationFrame(tick);
+    };
+    window.addEventListener("scroll", req, { passive: true });
+    window.addEventListener("resize", req, { passive: true });
+    desktopMQ.addEventListener?.("change", req);
+    reducedMQ.addEventListener?.("change", req);
+
+    return () => {
+      window.removeEventListener("scroll", req);
+      window.removeEventListener("resize", req);
+      desktopMQ.removeEventListener?.("change", req);
+      reducedMQ.removeEventListener?.("change", req);
+    };
+  }, [items, isBrowser]);
+
+  return (
+    <section id="labs" className="labs-section" aria-labelledby="labs-title" ref={sectionRef}>
+      <div className="labs-backdrop" aria-hidden="true" />
+      <div className="labs-inner">
+        <div className="labs-stars" aria-hidden="true" ref={starsRef}>
+          <div className="labs-orb" data-labs-orb aria-hidden="true" ref={orbRef} />
+        </div>
+
+        <header className="labs-head">
+          <h2 id="labs-title" className="labs-title" data-reveal data-reveal-index="0">
+            SwiftSend <span className="labs-title-gradient">Labs</span>
+          </h2>
+          <div className="labs-subtitle" data-reveal data-reveal-index="1">
+            <p>Affordable, Personalized, Innovative</p>
+            <p>Labs = testing ground for affordable experiments clients can actually use.</p>
+          </div>
+        </header>
+
+        <ul className="labs-grid" role="list" data-labs-grid ref={gridRef} />
+
+        <div className="labs-beta-cta" data-reveal data-reveal-index="8">
+          <a className="labs-beta-button" href="#contact">
+            Join the Labs Beta Program
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -13,6 +13,9 @@
   --ss-bg3: #110622;
   --ease: cubic-bezier(.2,.8,.2,1);
   --dur: 220ms;
+  --radius-xl: 18px;
+  --blur: 14px;
+  --grad: linear-gradient(90deg, #ff8a00 0%, #d63cff 100%);
 }
 
 html, body {
@@ -1059,6 +1062,492 @@ body.is-about-js .about [data-reveal].is-in {
   .achv-card:hover,
   .achv-card:focus-visible {
     transform: none !important;
+  }
+}
+
+
+/* === Labs Section === */
+.labs-section {
+  position: relative;
+  padding: clamp(4rem, 12vw, 7rem) clamp(1.5rem, 7vw, 4rem);
+  overflow: hidden;
+  color: #f4f6ff;
+}
+
+.labs-section * {
+  box-sizing: border-box;
+}
+
+.labs-backdrop {
+  position: absolute;
+  inset: -18% -24%;
+  background:
+    radial-gradient(60% 60% at 18% 18%, rgba(255, 138, 0, 0.24) 0%, rgba(255, 138, 0, 0) 70%),
+    radial-gradient(80% 80% at 82% 22%, rgba(68, 132, 255, 0.3) 0%, rgba(68, 132, 255, 0) 62%),
+    linear-gradient(140deg, rgba(22, 7, 44, 0.92) 0%, rgba(15, 6, 32, 0.86) 45%, rgba(9, 3, 25, 0.9) 100%);
+  filter: blur(40px);
+  opacity: 0.92;
+  transform: scale(1.05);
+}
+
+.labs-inner {
+  position: relative;
+  z-index: 1;
+  width: min(1080px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: clamp(2.5rem, 5vw, 3.5rem);
+}
+
+.labs-stars {
+  position: absolute;
+  inset: clamp(-12rem, -10vw, -8rem);
+  pointer-events: none;
+  overflow: hidden;
+  z-index: -1;
+}
+
+.labs-star,
+.labs-glow {
+  position: absolute;
+  left: var(--left, 50%);
+  top: var(--top, 50%);
+  width: var(--size, 2px);
+  height: var(--size, 2px);
+  border-radius: 999px;
+  opacity: 0;
+  animation: labs-twinkle var(--twinkle-duration, 4s) ease-in-out infinite;
+  animation-delay: var(--twinkle-delay, 0s);
+  will-change: opacity, transform;
+}
+
+.labs-star {
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0) 70%);
+  box-shadow: 0 0 14px rgba(255, 255, 255, 0.45);
+}
+
+.labs-glow {
+  background: radial-gradient(circle at 50% 50%, rgba(130, 90, 255, 0.65) 0%, rgba(130, 90, 255, 0) 70%);
+  filter: blur(var(--blur, 6px));
+}
+
+.labs-orb {
+  position: absolute;
+  inset: auto auto 12% 62%;
+  width: clamp(120px, 28vw, 220px);
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 30% 30%, rgba(255, 174, 67, 0.55) 0%, rgba(255, 174, 67, 0) 60%),
+    radial-gradient(circle at 70% 70%, rgba(108, 214, 255, 0.6) 0%, rgba(108, 214, 255, 0) 65%),
+    radial-gradient(circle at 50% 50%, rgba(112, 40, 255, 0.5) 0%, rgba(112, 40, 255, 0) 70%);
+  filter: blur(12px);
+  opacity: 0.82;
+  mix-blend-mode: screen;
+  transition: transform 0.6s var(--ease);
+}
+
+.labs-head {
+  display: grid;
+  gap: 1rem;
+  text-align: center;
+  justify-items: center;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.labs-title {
+  font-size: clamp(2.4rem, 6vw, 3.4rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  margin: 0;
+}
+
+.labs-title-gradient {
+  background: var(--grad);
+  -webkit-background-clip: text;
+  color: transparent;
+  background-clip: text;
+}
+
+.labs-subtitle {
+  display: grid;
+  gap: 0.3rem;
+  color: rgba(244, 246, 255, 0.82);
+  font-size: clamp(1.05rem, 2.6vw, 1.2rem);
+  line-height: 1.55;
+}
+
+.labs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(1.5rem, 4vw, 2.2rem);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.labs-card {
+  position: relative;
+  padding: clamp(1.6rem, 2.5vw, 2.1rem);
+  border-radius: var(--radius-xl);
+  background: linear-gradient(160deg, rgba(24, 10, 46, 0.86) 0%, rgba(18, 6, 36, 0.92) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: 0 20px 45px rgba(7, 3, 18, 0.6);
+  display: grid;
+  gap: 1.4rem;
+  overflow: hidden;
+  transition: transform 0.4s var(--ease), border-color 0.4s var(--ease), box-shadow 0.4s var(--ease);
+  isolation: isolate;
+}
+
+.labs-card::before {
+  content: "";
+  position: absolute;
+  inset: -40% -60% auto;
+  height: 220%;
+  background: radial-gradient(circle at 20% 20%, var(--labs-card-accent, rgba(255, 138, 0, 0.32)) 0%, rgba(0, 0, 0, 0) 65%);
+  opacity: 0;
+  transform: translate3d(0, 18px, 0) scale(0.9);
+  transition: opacity 0.6s var(--ease), transform 0.6s var(--ease);
+  z-index: -2;
+}
+
+.labs-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0) 60%);
+  opacity: 0;
+  transition: opacity 0.5s var(--ease);
+  z-index: -1;
+}
+
+.labs-card.is-in,
+.labs-card:hover,
+.labs-card:focus-within {
+  transform: translateY(-6px);
+  border-color: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 26px 50px rgba(9, 3, 24, 0.7);
+}
+
+.labs-card:hover::before,
+.labs-card:focus-within::before {
+  opacity: 0.7;
+  transform: translate3d(0, 0, 0) scale(1);
+}
+
+.labs-card:hover::after,
+.labs-card:focus-within::after {
+  opacity: 0.2;
+}
+
+.labs-status {
+  justify-self: flex-start;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.labs-status--beta {
+  background: rgba(255, 138, 0, 0.14);
+  border-color: rgba(255, 138, 0, 0.36);
+  color: #ffb057;
+}
+
+.labs-status--beta-alt {
+  background: rgba(95, 198, 255, 0.18);
+  border-color: rgba(95, 198, 255, 0.4);
+  color: #8edbff;
+}
+
+.labs-status--live {
+  background: rgba(40, 190, 120, 0.18);
+  border-color: rgba(40, 190, 120, 0.35);
+  color: #6ce2b3;
+}
+
+.labs-status--coming {
+  background: rgba(86, 198, 255, 0.18);
+  border-color: rgba(86, 198, 255, 0.4);
+  color: #7fd0ff;
+}
+
+.labs-status--prototype {
+  background: rgba(244, 123, 188, 0.2);
+  border-color: rgba(244, 123, 188, 0.4);
+  color: #ffc9e3;
+}
+
+.labs-icon {
+  width: clamp(58px, 8vw, 64px);
+  aspect-ratio: 1 / 1;
+  border-radius: 20px;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.06);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 18px rgba(255, 255, 255, 0.08);
+}
+
+.labs-icon svg {
+  width: 28px;
+  height: 28px;
+  stroke-width: 1.6;
+  stroke: currentColor;
+  fill: none;
+}
+
+.labs-card-body {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.labs-card-title {
+  margin: 0;
+  font-size: clamp(1.2rem, 2.8vw, 1.4rem);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: #fefbff;
+}
+
+.labs-card-blurb {
+  margin: 0;
+  color: rgba(235, 238, 255, 0.76);
+  line-height: 1.55;
+  font-size: 0.98rem;
+}
+
+.labs-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-top: 0.2rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  text-decoration: none;
+  position: relative;
+  transition: color 0.3s var(--ease);
+}
+
+.labs-cta::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.15rem;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.7));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.35s var(--ease);
+}
+
+.labs-card:hover .labs-cta,
+.labs-card:focus-within .labs-cta {
+  color: #ffffff;
+}
+
+.labs-card:hover .labs-cta::after,
+.labs-card:focus-within .labs-cta::after {
+  transform: scaleX(1);
+}
+
+.labs-rail {
+  position: absolute;
+  left: clamp(1.6rem, 5vw, 2.4rem);
+  right: clamp(1.6rem, 5vw, 2.4rem);
+  bottom: clamp(1.4rem, 4vw, 1.8rem);
+  height: 2px;
+  border-radius: 999px;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.labs-rail--comet::before,
+.labs-rail--comet::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.85) 45%, rgba(255, 255, 255, 0) 100%);
+  transform: translateX(-110%);
+  opacity: 0;
+}
+
+.labs-rail--comet::after {
+  filter: blur(6px);
+}
+
+.labs-rail--comet.is-playing::before,
+.labs-rail--comet.is-playing::after,
+.labs-card:hover .labs-rail--comet::before,
+.labs-card:hover .labs-rail--comet::after,
+.labs-card:focus-within .labs-rail--comet::before,
+.labs-card:focus-within .labs-rail--comet::after {
+  animation: labs-comet 1.4s var(--ease) forwards;
+}
+
+.labs-card--orange {
+  --labs-card-accent: rgba(255, 138, 0, 0.34);
+  color: #fff0d8;
+}
+
+.labs-card--green {
+  --labs-card-accent: rgba(60, 215, 140, 0.32);
+}
+
+.labs-card--cyan {
+  --labs-card-accent: rgba(86, 198, 255, 0.36);
+}
+
+.labs-card--purple {
+  --labs-card-accent: rgba(168, 120, 255, 0.32);
+}
+
+.labs-card--rose {
+  --labs-card-accent: rgba(244, 123, 188, 0.36);
+}
+
+.labs-card--blueCyan {
+  --labs-card-accent: rgba(95, 198, 255, 0.36);
+}
+
+.labs-card--green .labs-icon { color: #7decb7; }
+.labs-card--cyan .labs-icon { color: #7fd0ff; }
+.labs-card--purple .labs-icon { color: #d4b3ff; }
+.labs-card--rose .labs-icon { color: #ffb7de; }
+.labs-card--blueCyan .labs-icon { color: #8bdcff; }
+
+.labs-card--orange .labs-icon {
+  color: #ffbe76;
+}
+
+.labs-card--green .labs-status { color: #7decb7; }
+.labs-card--cyan .labs-status { color: #7fd0ff; }
+.labs-card--purple .labs-status { color: #e0c0ff; }
+.labs-card--rose .labs-status { color: #ffc9e3; }
+.labs-card--blueCyan .labs-status { color: #8edbff; }
+
+.labs-beta-cta {
+  display: grid;
+  place-items: center;
+}
+
+.labs-beta-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  padding: 0.9rem clamp(1.8rem, 5vw, 2.6rem);
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #1d0f36;
+  background: var(--grad);
+  box-shadow: 0 18px 35px rgba(255, 138, 0, 0.28);
+  transition: transform 0.35s var(--ease), box-shadow 0.35s var(--ease);
+}
+
+.labs-beta-button:hover,
+.labs-beta-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 45px rgba(255, 138, 0, 0.35);
+  text-decoration: none;
+}
+
+.labs-beta-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 4px;
+}
+
+[data-reveal] {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s var(--ease), transform 0.6s var(--ease);
+}
+
+[data-reveal].is-in {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@keyframes labs-twinkle {
+  0%,
+  100% {
+    opacity: var(--twinkle-min, 0.3);
+  }
+  50% {
+    opacity: var(--twinkle-max, 0.9);
+  }
+}
+
+@keyframes labs-comet {
+  0% {
+    transform: translateX(-115%);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  70% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(120%);
+    opacity: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .labs-inner {
+    gap: 2.2rem;
+  }
+
+  .labs-head {
+    text-align: left;
+    justify-items: flex-start;
+    margin-inline: 0;
+  }
+
+  .labs-subtitle {
+    justify-items: flex-start;
+  }
+
+  .labs-rail {
+    left: clamp(1.2rem, 8vw, 1.8rem);
+    right: clamp(1.2rem, 8vw, 1.8rem);
+  }
+
+  .labs-beta-cta {
+    justify-items: stretch;
+  }
+
+  .labs-beta-button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .labs-section,
+  .labs-section * {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+
+  .labs-rail--comet::before,
+  .labs-rail--comet::after {
+    animation: none !important;
+    transform: translateX(0);
+    opacity: 0.4;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the placeholder Labs area with a client-rendered Labs section that builds cards, starfield twinkles, and parallax orb effects on view
- add dedicated Labs styling for cards, reveal animations, comet rails, and responsive layout tokens
- wire the Labs section into the home page composition and add a simple health-check GET route response

## Testing
- npm run dev
- npm run build *(fails: Next.js prerender error `Cannot read properties of undefined (reading 'clientModules')`)*

------
https://chatgpt.com/codex/tasks/task_e_68e615159cf0832fa2967d5bffc39f0b